### PR TITLE
refactor: remove unused alt/plaf fields from CELLS flight records

### DIFF
--- a/docs/FIELDS_MAPPING.md
+++ b/docs/FIELDS_MAPPING.md
@@ -174,3 +174,40 @@ with open('neural_network/bin/data/flights_by_cell_day_spot.pkl', 'wb') as f:
 - 46_13 (46°N, 13°E) — 6,393 полёта
 - 45_13 (45°N, 13°E) — 3,468 полётов
 - 46_14 (46°N, 14°E) — 1,049 полётов
+
+---
+
+## Обновление PKL структуры (Issue #16)
+
+**Дата:** 2026-01-03
+
+### Удалены неиспользуемые поля из CELLS model
+
+Поскольку xContest JSON не предоставляет данные о высоте (`alt`, `plaf`), а эти поля не использовались в обучении, они были удалены из PKL структуры.
+
+**Было (7 полей):**
+```python
+(datetime, (score, alt, plaf, lat, lon, takeoff_alt, mountainess))
+#         [0]    [1][0] [1][1] [1][2] [1][3] [1][4] [1][5]      [1][6]
+```
+
+**Стало (5 полей):**
+```python
+(datetime, (score, lat, lon, takeoff_alt, mountainess))
+#         [0]    [1][0] [1][1] [1][2] [1][3]      [1][4]
+```
+
+### Убраны:
+- **`alt`** (f[1][1]) - был 0.0, не использовался
+- **`plaf`** (f[1][2]) - был avgSpeed, семантически неверно, не использовался
+
+### Остались:
+- **`score`** (f[1][0]) - используется для crossability threshold
+- **`lat`** (f[1][1]) - используется для super-resolution
+- **`lon`** (f[1][2]) - используется для super-resolution
+- **`takeoff_alt`** (f[1][3]) - из DEM/SRTM, используется для altitude binning
+- **`mountainess`** (f[1][4]) - из DEM/SRTM, используется в модели
+
+### TODO для будущей оптимизации:
+- `takeoff_alt` можно вычислять на лету из DEM по lat/lon (~16 байт/полёт)
+- `mountainess` хранится дублированно (per-flight и per-cell в отдельном файле)

--- a/specs/PKL_DATASET_PIPELINE.md
+++ b/specs/PKL_DATASET_PIPELINE.md
@@ -66,17 +66,15 @@
 
 Список полётов по ячейкам и дням.
 
-- Тип: `List[List[Tuple[str, Tuple[float, float, float, float, float, float, float]]]]`
+- Тип: `List[List[Tuple[str, Tuple[float, float, float, float, float]]]]`
 - Размер списка: `nb_days * nb_cells`
 - Индекс: `day_idx * nb_cells + cell_idx`
 - Один полёт:
-  - `("YYYY-MM-DD HH:MM:SS", (score, alt, plaf, lat, lon, takeoff_alt, mountainess))`
+  - `("YYYY-MM-DD HH:MM:SS", (score, lat, lon, takeoff_alt, mountainess))`
     - `score`: XC score (баллы) из `parse_igc_with_libs.py`, используется для crossability (порог 60)
-    - `alt`: дополнительный параметр (в коде напрямую не используется)
-    - `plaf`: потолок (макс. высота), используется в аналитике
     - `lat`, `lon`: координаты старта
-    - `takeoff_alt`: высота старта (используется для kAltitude)
-    - `mountainess`: дубль значения по ячейке
+    - `takeoff_alt`: высота старта из DEM/SRTM (используется для kAltitude)
+    - `mountainess`: гористость из DEM/SRTM (дубль значения по ячейке)
 
 ### 1.8 `spots.pkl`, `spots_merged.pkl`
 

--- a/src/pyparaglide/data/dataset.py
+++ b/src/pyparaglide/data/dataset.py
@@ -243,7 +243,7 @@ class Dataset:
             for k_dc, dc in enumerate(lines):
                 for flight in self.flights_by_cell_day[dc]:
                     # Calculate super-resolution cell position
-                    lat, lon = flight[1][3], flight[1][4]
+                    lat, lon = flight[1][1], flight[1][2]
                     sr_x = int(((lon + 0.5) % 1.0) * super_resolution)
                     sr_y = int(((lat + 0.5) % 1.0) * super_resolution)
                     flight_list[sr_y * super_resolution + sr_x][k_dc].append(flight)
@@ -255,16 +255,16 @@ class Dataset:
                     if len(daycell) > 0:
                         if regression:
                             for k_alt in range(nb_altitudes):
-                                flown = sum(1 for f in daycell if self._k_altitude(f[1][5]) == k_alt)
-                                crossed = sum(1 for f in daycell if self._k_altitude(f[1][5]) == k_alt and f[1][0] >= points_limit)
+                                flown = sum(1 for f in daycell if self._k_altitude(f[1][3]) == k_alt)
+                                crossed = sum(1 for f in daycell if self._k_altitude(f[1][3]) == k_alt and f[1][0] >= points_limit)
 
                                 res[0][res_line, k_alt] = flown
                                 res[1][res_line, k_alt] = crossed
                                 res[2][res_line, k_alt] = flown
                                 res[3][res_line, k_alt] = flown
                         else:
-                            flown_alts = {self._k_altitude(f[1][5]) for f in daycell}
-                            crossed_alts = {self._k_altitude(f[1][5]) for f in daycell if f[1][0] >= points_limit}
+                            flown_alts = {self._k_altitude(f[1][3]) for f in daycell}
+                            crossed_alts = {self._k_altitude(f[1][3]) for f in daycell if f[1][0] >= points_limit}
 
                             for alt in flown_alts:
                                 res[0][res_line, alt] = 1.0

--- a/src/pyparaglide/preprocessing/flights/flight_processor.py
+++ b/src/pyparaglide/preprocessing/flights/flight_processor.py
@@ -621,13 +621,15 @@ def create_spots_pkls(flights: List[Dict],
                 record = (
                     f['datetime'],
                     (
-                        float(f.get('score', 0.0) or 0.0),
-                        float(f.get('alt', 0.0) or 0.0),
-                        float(f.get('plaf', 0.0) or 0.0),
-                        float(f['lat']),
-                        float(f['lon']),
-                        float(f.get('takeoff_alt', 0.0) or 0.0),
-                        float(f.get('mountainess', 0.5) or 0.5)
+                        float(f.get('score', 0.0) or 0.0),        # [1][0]
+                        float(f['lat']),                          # [1][1]
+                        float(f['lon']),                          # [1][2]
+                        # TODO: optimize - could compute takeoff_alt on-the-fly from DEM
+                        # using lat/lon instead of storing in PKL (saves ~16 bytes/flight)
+                        float(f.get('takeoff_alt', 0.0) or 0.0), # [1][3] - from DEM/SRTM
+                        # TODO: optimize - could compute mountainess on-the-fly from DEM
+                        # or store per-cell instead of per-flight (currently duplicated)
+                        float(f.get('mountainess', 0.5) or 0.5)  # [1][4] - from DEM/SRTM
                     )
                 )
 


### PR DESCRIPTION
## Summary

Remove unused `alt` and `plaf` fields from CELLS model flight records in `flights_by_cell_day.pkl`. These fields are not available in xContest JSON data and were not used in training.

## Changes

### Code Changes
- **flight_processor.py**: Remove `alt` and `plaf` from tuple creation, add TODO comments for future optimization
- **dataset.py**: Update field indices after removal:
  - `lat, lon`: `[1][3],[1][4]` → `[1][1],[1][2]`
  - `takeoff_alt`: `[1][5]` → `[1][3]`

### Documentation Updates
- **PKL_DATASET_PIPELINE.md**: Update tuple structure documentation (7 fields → 5 fields)
- **FIELDS_MAPPING.md**: Add section documenting the PKL structure change

## Structure Change

**Before:**
```python
(datetime, (score, alt, plaf, lat, lon, takeoff_alt, mountainess))
#         [0]    [1][0] [1][1] [1][2] [1][3] [1][4] [1][5]      [1][6]
```

**After:**
```python
(datetime, (score, lat, lon, takeoff_alt, mountainess))
#         [0]    [1][0] [1][1] [1][2] [1][3]      [1][4]
```

## Removed Fields
- **`alt`** - Was always 0.0 (xContest doesn't provide max altitude)
- **`plaf`** - Was avgSpeed (semantically incorrect, not used in training)

## Testing
- ✅ All 80 unit tests pass
- ✅ No integration test failures

## Related
- Fixes #16