### PR TITLE
feat: add download subcommands (dl) with forecast support

### DIFF
--- a/src/pyparaglide/cli/__init__.py
+++ b/src/pyparaglide/cli/__init__.py
@@ -21,7 +21,7 @@ warnings.filterwarnings("ignore", message=".*ROC AUC score.*")
 from pyparaglide import __version__
 from pyparaglide.analysis import FlightAnalyzer, MeteoAnalyzer
 from pyparaglide.config import get_settings, parse_date_ranges
-from pyparaglide.downloads import GFSDownloader
+from pyparaglide.downloads import GFSDownloader, GFSForecastDownloader
 from pyparaglide.inference import Forecaster
 from pyparaglide.models.enums import ModelType, ProblemFormulation
 from pyparaglide.preprocessing import DatasetBuilder
@@ -117,6 +117,10 @@ def info() -> None:
 # Analyze subcommand
 analyze_app = typer.Typer(help="Analyze flights and weather data", add_completion=False)
 app.add_typer(analyze_app, name="analyze")
+
+# Download subcommands (short alias 'dl' to avoid conflict with flat 'download' command)
+download_app = typer.Typer(help="Download GFS weather and elevation data (subcommands)", add_completion=False)
+app.add_typer(download_app, name="dl")
 
 
 @analyze_app.command()
@@ -411,6 +415,123 @@ Missing days: {len(result.missing_days)}"""
         console.print(f"  [cyan]pyparaglide download --dates \"{','.join(range_strs)}\"[/cyan]")
     else:
         console.print(f"[green]All expected days are available![/green]")
+
+
+# =============================================================================
+# Download Subcommands
+# =============================================================================
+
+
+@download_app.command("analysis")
+def download_analysis(
+    dates: str = typer.Option(None, "--dates", "-D", help="Date ranges (format: YYYY-MM-DD:YYYY-MM-DD,...)"),
+    start_date: str = typer.Option(None, "--start", "-s", help="Start date (YYYY-MM-DD)"),
+    end_date: str = typer.Option(None, "--end", "-e", help="End date (YYYY-MM-DD)"),
+    data_dir: str = typer.Option(None, "--data-dir", "-d", help="Output directory for GRIB files"),
+    hours: str = typer.Option("0,6,12,18", "--hours", "-H", help="UTC hours to download (comma-separated)"),
+    workers: int = typer.Option(1, "--workers", "-w", help="Number of parallel download workers"),
+    filter: bool = typer.Option(False, "--filter", help="Filter GRIB files to reduce size by ~50%"),
+) -> None:
+    """
+    Download GFS Analysis data (historical weather for training).
+
+    Downloads historical GFS Analysis GRIB files from AWS S3 for neural network training.
+
+    Examples:
+        pyparaglide download analysis --dates 2024-06-01:2024-08-31
+        pyparaglide download analysis --start 2024-06-01 --end 2024-08-31
+        pyparaglide download analysis --workers 4 --filter
+    """
+    from pyparaglide.cli._download_helpers import download_analysis_impl
+
+    download_analysis_impl(
+        dates=dates,
+        start_date=start_date,
+        end_date=end_date,
+        data_dir=data_dir,
+        hours=hours,
+        workers=workers,
+        filter_grib=filter,
+    )
+
+
+@download_app.command("forecast")
+def download_forecast(
+    date: str = typer.Option(..., "--date", "-d", help="Target date (YYYY-MM-DD)"),
+    data_dir: str = typer.Option(None, "--data-dir", "-o", help="Output directory for GRIB files"),
+    hours: str = typer.Option("6,12,18", "--hours", "-H", help="Forecast hours to download (comma-separated)"),
+) -> None:
+    """
+    Download GFS Forecast data (for generating predictions).
+
+    Downloads GFS Forecast GRIB files from NOMADS for generating flyability predictions.
+    Files are saved as YYYYMMDD-HH.grib2 in the forecasts subdirectory.
+
+    Examples:
+        pyparaglide download forecast --date 2025-01-04
+        pyparaglide download forecast --date 2025-01-04 --hours 6,12,18
+    """
+    import datetime as dt
+
+    settings = get_settings()
+
+    if data_dir is None:
+        data_dir = settings.gfs_dir
+
+    # Parse target date
+    try:
+        target_date = dt.datetime.strptime(date, "%Y-%m-%d").date()
+    except ValueError:
+        console.print(f"[red]Invalid date format: {date}[/red]")
+        console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
+        raise typer.Exit(1)
+
+    console.print(f"[bold cyan]Downloading GFS Forecast data[/bold cyan]")
+    console.print(f"[dim]Date: {target_date.isoformat()}[/dim]")
+    console.print(f"[dim]Hours: {hours}[/dim]\n")
+
+    # Create downloader
+    downloader = GFSForecastDownloader(
+        data_dir=data_dir,
+    )
+
+    # Parse hours
+    hour_list = [int(h.strip()) for h in hours.split(",")]
+    downloader.forecast_hours = hour_list
+
+    # Download
+    stats = downloader.download_day(target_date)
+
+    # Print summary
+    console.print(f"\n[bold]Download Summary:[/bold]")
+    console.print(f"  Downloaded: {stats['downloaded']} files ({stats['total_mb']:.1f} MB)")
+    console.print(f"  Skipped: {stats['skipped']} files")
+    console.print(f"  Failed: {stats['failed']} files")
+
+    if stats["failed"] > 0:
+        raise typer.Exit(1)
+
+
+@download_app.command("elevation")
+def download_elevation(
+    data_dir: str = typer.Option(None, "--data-dir", "-o", help="Output directory for elevation files"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box: lat_min,lat_max,lon_min,lon_max"),
+) -> None:
+    """
+    Download SRTM elevation data.
+
+    Downloads SRTM elevation tiles for terrain modeling.
+
+    Examples:
+        pyparaglide download elevation
+        pyparaglide download elevation --bbox 45,47,13,15
+    """
+    from pyparaglide.cli._download_helpers import download_elevation_impl
+
+    download_elevation_impl(
+        data_dir=data_dir,
+        bbox=bbox,
+    )
 
 
 @app.command()
@@ -1009,6 +1130,11 @@ def download(
     """
     Download GFS Analysis and Elevation data.
 
+    [bold yellow]New:[/bold yellow] Use subcommands for more control:
+      - [cyan]pyparaglide dl analysis[/cyan] for GFS Analysis
+      - [cyan]pyparaglide dl forecast[/cyan] for GFS Forecast
+      - [cyan]pyparaglide dl elevation[/cyan] for elevation
+
     Downloads historical GFS Analysis GRIB files and/or SRTM elevation data.
 
     Date sources (in order of priority):
@@ -1042,108 +1168,25 @@ def download(
         # With options
         pyparaglide download --workers 4 --filter
     """
-    import datetime as dt
+    from pyparaglide.cli._download_helpers import download_analysis_impl, download_elevation_impl
 
-    settings = get_settings()
-
-    # ==============================================================================
-    # GFS Download
-    # ==============================================================================
+    # Call helpers
     if not skip_gfs:
-        if data_dir is None:
-            data_dir = settings.gfs_dir
-
-        # Parse hours
-        hour_list = [int(h.strip()) for h in hours.split(",")]
-
-        console.print(f"[bold cyan]Downloading GFS Analysis data[/bold cyan]\n")
-
-        # Determine date ranges (priority: --dates > --start/--end > .env TRAINING_DATES)
-        if dates:
-            # Parse --dates argument (same format as .env)
-            try:
-                date_ranges = parse_date_ranges(dates)
-            except ValueError as e:
-                console.print(f"[red]{e}[/red]")
-                raise typer.Exit(1)
-        elif start_date and end_date:
-            # Legacy --start/--end format (single range)
-            try:
-                date_ranges = parse_date_ranges(f"{start_date}:{end_date}")
-            except ValueError:
-                console.print(f"[red]Invalid date format[/red]")
-                console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
-                raise typer.Exit(1)
-        elif start_date or end_date:
-            # Only one of --start/--end specified
-            console.print("[red]Error: --start and --end must be used together, or use --dates instead[/red]")
-            raise typer.Exit(1)
-        else:
-            # Use ranges from .env TRAINING_DATES
-            # parse_training_dates returns strings, so we need to convert back to dates
-            str_ranges = settings.parse_training_dates()
-            if not str_ranges:
-                console.print("[red]Error: No date ranges found. Specify --dates, --start/--end, or set TRAINING_DATES in .env[/red]")
-                raise typer.Exit(1)
-            date_ranges = [
-                (dt.datetime.strptime(start, "%Y-%m-%d").date(),
-                 dt.datetime.strptime(end, "%Y-%m-%d").date())
-                for start, end in str_ranges
-            ]
-
-        # Create downloader
-        from pyparaglide.downloads.gfs_downloader import GFSDownloader
-
-        downloader = GFSDownloader(
+        download_analysis_impl(
+            dates=dates,
+            start_date=start_date,
+            end_date=end_date,
             data_dir=data_dir,
-            hours=hour_list,
+            hours=hours,
             workers=workers,
             filter_grib=filter,
         )
 
-        # Download all ranges
-        total_stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
-
-        for start, end in date_ranges:
-            console.print(f"\n[yellow]Processing range: {start} to {end}[/yellow]")
-            stats = downloader.download_range(start, end)
-
-            for key in total_stats:
-                if key != "total_mb":
-                    total_stats[key] += stats[key]
-            total_stats["total_mb"] += stats["total_mb"]
-
-        # Print summary
-        console.print(f"\n[bold]GFS Download Summary:[/bold]")
-        console.print(f"  Downloaded: {total_stats['downloaded']} files ({total_stats['total_mb']:.1f} MB)")
-        console.print(f"  Skipped: {total_stats['skipped']} files")
-        console.print(f"  Failed: {total_stats['failed']} files")
-
-        # Return exit code based on failures
-        if total_stats["failed"] > 0:
-            raise typer.Exit(1)
-
-    # ==============================================================================
-    # Elevation Download
-    # ==============================================================================
     if not skip_elevation:
-        console.print(f"\n[bold cyan]Downloading Elevation data[/bold cyan]\n")
-
-        from pyparaglide.downloads.elevation_downloader import ElevationDownloader
-
-        bbox = settings.parse_bbox()
-        downloader = ElevationDownloader(
-            data_dir=settings.elevation_dir,
-            bbox=bbox,
-            product=settings.elevation_source,  # SRTM1 (30m) or SRTM3 (90m)
+        download_elevation_impl(
+            data_dir=data_dir,
+            bbox=None,
         )
-
-        stats = downloader.download()
-
-        console.print(f"\n[bold]Elevation Download Summary:[/bold]")
-        console.print(f"  Source: {stats['source']}")
-        console.print(f"  BBox: {stats['bbox']}")
-        console.print(f"  Output: {stats['output_size_mb']:.1f} MB")
 
     if skip_gfs and skip_elevation:
         console.print("[yellow]Warning: Both --skip-gfs and --skip-elevation specified, nothing to download[/yellow]")

--- a/src/pyparaglide/cli/_download_helpers.py
+++ b/src/pyparaglide/cli/_download_helpers.py
@@ -1,0 +1,150 @@
+"""
+Helper functions for download commands.
+
+Extracted to enable both flat and subcommand interfaces.
+"""
+
+import datetime as dt
+
+from rich.console import Console
+import typer
+
+from pyparaglide.config import get_settings, parse_date_ranges
+from pyparaglide.downloads import GFSDownloader, ElevationDownloader
+
+console = Console()
+
+
+def download_analysis_impl(
+    dates: str | None,
+    start_date: str | None,
+    end_date: str | None,
+    data_dir: str | None,
+    hours: str,
+    workers: int,
+    filter_grib: bool,
+) -> None:
+    """
+    Implementation for GFS Analysis download.
+
+    Shared by both flat command and subcommand.
+
+    Args:
+        dates: Date ranges string (format: YYYY-MM-DD:YYYY-MM-DD,...)
+        start_date: Start date string (YYYY-MM-DD)
+        end_date: End date string (YYYY-MM-DD)
+        data_dir: Output directory for GRIB files
+        hours: UTC hours to download (comma-separated string)
+        workers: Number of parallel download workers
+        filter_grib: Filter GRIB files to reduce size
+    """
+    settings = get_settings()
+
+    if data_dir is None:
+        data_dir = settings.gfs_dir
+
+    # Parse hours
+    hour_list = [int(h.strip()) for h in hours.split(",")]
+
+    console.print(f"[bold cyan]Downloading GFS Analysis data[/bold cyan]\n")
+
+    # Determine date ranges (priority: --dates > --start/--end > .env TRAINING_DATES)
+    if dates:
+        try:
+            date_ranges = parse_date_ranges(dates)
+        except ValueError as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1)
+    elif start_date and end_date:
+        try:
+            date_ranges = parse_date_ranges(f"{start_date}:{end_date}")
+        except ValueError:
+            console.print(f"[red]Invalid date format[/red]")
+            console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
+            raise typer.Exit(1)
+    elif start_date or end_date:
+        console.print("[red]Error: --start and --end must be used together, or use --dates instead[/red]")
+        raise typer.Exit(1)
+    else:
+        str_ranges = settings.parse_training_dates()
+        if not str_ranges:
+            console.print("[red]Error: No date ranges found. Specify --dates, --start/--end, or set TRAINING_DATES in .env[/red]")
+            raise typer.Exit(1)
+        date_ranges = [
+            (
+                dt.datetime.strptime(start, "%Y-%m-%d").date(),
+                dt.datetime.strptime(end, "%Y-%m-%d").date(),
+            )
+            for start, end in str_ranges
+        ]
+
+    # Create downloader
+    downloader = GFSDownloader(
+        data_dir=data_dir,
+        hours=hour_list,
+        workers=workers,
+        filter_grib=filter_grib,
+    )
+
+    # Download all ranges
+    total_stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
+
+    for start, end in date_ranges:
+        console.print(f"\n[yellow]Processing range: {start} to {end}[/yellow]")
+        stats = downloader.download_range(start, end)
+
+        total_stats["downloaded"] += stats["downloaded"]
+        total_stats["skipped"] += stats["skipped"]
+        total_stats["failed"] += stats["failed"]
+        total_stats["total_mb"] += stats["total_mb"]
+
+    # Print summary
+    console.print(f"\n[bold]GFS Download Summary:[/bold]")
+    console.print(f"  Downloaded: {total_stats['downloaded']} files ({total_stats['total_mb']:.1f} MB)")
+    console.print(f"  Skipped: {total_stats['skipped']} files")
+    console.print(f"  Failed: {total_stats['failed']} files")
+
+    if total_stats["failed"] > 0:
+        raise typer.Exit(1)
+
+
+def download_elevation_impl(data_dir: str | None, bbox: str | None) -> None:
+    """
+    Implementation for elevation download.
+
+    Shared by both flat command and subcommand.
+
+    Args:
+        data_dir: Output directory for elevation files
+        bbox: Bounding box string (lat_min,lat_max,lon_min,lon_max)
+    """
+    settings = get_settings()
+
+    console.print(f"\n[bold cyan]Downloading Elevation data[/bold cyan]\n")
+
+    if data_dir is None:
+        data_dir = settings.elevation_dir
+
+    if bbox is None:
+        bbox_tuple = settings.parse_bbox()
+    else:
+        # Parse bbox from string
+        parts = [float(x.strip()) for x in bbox.split(",")]
+        if len(parts) != 4:
+            console.print(f"[red]Invalid bbox format: {bbox}[/red]")
+            console.print("Expected: lat_min,lat_max,lon_min,lon_max")
+            raise typer.Exit(1)
+        bbox_tuple = (parts[0], parts[1], parts[2], parts[3])
+
+    downloader = ElevationDownloader(
+        data_dir=data_dir,
+        bbox=bbox_tuple,
+        product=settings.elevation_source,
+    )
+
+    stats = downloader.download()
+
+    console.print(f"\n[bold]Elevation Download Summary:[/bold]")
+    console.print(f"  Source: {stats['source']}")
+    console.print(f"  BBox: {stats['bbox']}")
+    console.print(f"  Output: {stats['output_size_mb']:.1f} MB")

--- a/src/pyparaglide/downloads/__init__.py
+++ b/src/pyparaglide/downloads/__init__.py
@@ -6,5 +6,6 @@ Handles downloading of GFS weather data from NOAA and elevation data.
 
 from pyparaglide.downloads.elevation_downloader import ElevationDownloader
 from pyparaglide.downloads.gfs_downloader import GFSDownloader
+from pyparaglide.downloads.gfs_forecast_downloader import GFSForecastDownloader
 
-__all__ = ["ElevationDownloader", "GFSDownloader"]
+__all__ = ["ElevationDownloader", "GFSDownloader", "GFSForecastDownloader"]

--- a/src/pyparaglide/downloads/gfs_downloader.py
+++ b/src/pyparaglide/downloads/gfs_downloader.py
@@ -80,7 +80,7 @@ class GFSDownloader:
         self,
         start_date: dt.date | str,
         end_date: dt.date | str,
-    ) -> dict[Literal["downloaded", "skipped", "failed", "total_mb"], int]:
+    ) -> dict[str, int | float]:
         """
         Download GFS data for a date range.
 

--- a/src/pyparaglide/downloads/gfs_forecast_downloader.py
+++ b/src/pyparaglide/downloads/gfs_forecast_downloader.py
@@ -1,0 +1,245 @@
+"""
+GFS Forecast data downloader from NOAA NOMADS.
+
+Downloads GFS Forecast GRIB files for generating flyability predictions.
+Uses NOMADS filter API for targeted parameter downloads.
+"""
+
+import datetime as dt
+import urllib.error
+import urllib.request
+from pathlib import Path
+from threading import Lock
+from typing import Literal
+
+from tqdm import tqdm
+
+
+class GFSForecastDownloader:
+    """
+    Download GFS Forecast data from NOAA NOMADS.
+
+    Downloads forecast GRIB files for specific dates and forecast hours.
+    Files are saved with naming convention: YYYYMMDD-HH.grib2
+    """
+
+    # NOMADS filter parameters (matching legacy GfsData from neural_network/inc/dataset.py)
+    _FORECAST_LEVELS = [
+        "lev_200_mb=on",
+        "lev_300_mb=on",
+        "lev_400_mb=on",
+        "lev_500_mb=on",
+        "lev_600_mb=on",
+        "lev_700_mb=on",
+        "lev_800_mb=on",
+        "lev_900_mb=on",
+        "lev_1000_mb=on",
+        "lev_entire_atmosphere=on",
+        "lev_entire_atmosphere_%5C%28considered_as_a_single_layer%5C%29=on",
+    ]
+
+    _FORECAST_VARS = [
+        "var_VVEL=on",  # Vertical velocity
+        "var_ABSV=on",  # Absolute vorticity
+        "var_CWAT=on",  # Cloud water
+        "var_HGT=on",  # Geopotential height
+        "var_PWAT=on",  # Precipitable water
+        "var_RH=on",  # Relative humidity
+        "var_TMP=on",  # Temperature
+        "var_UGRD=on",  # U component of wind
+        "var_VGRD=on",  # V component of wind
+    ]
+
+    GRID = "0p25"  # GFS resolution
+
+    def __init__(
+        self,
+        data_dir: Path | str,
+        max_retries: int = 3,
+    ):
+        """
+        Initialize GFS Forecast downloader.
+
+        Args:
+            data_dir: Output directory for forecast GRIB files
+            max_retries: Maximum retry attempts
+        """
+        self.data_dir = Path(data_dir)
+        self.max_retries = max_retries
+        self.min_file_size = 5 * 1024 * 1024  # 5 MB minimum
+
+        # Create forecasts subdirectory
+        self.forecasts_dir = self.data_dir / "forecasts"
+        self.forecasts_dir.mkdir(parents=True, exist_ok=True)
+
+        # Initialize tqdm lock for thread safety
+        tqdm.set_lock(Lock())
+
+        # Default forecast hours (matches forecast command expectation)
+        self.forecast_hours = [6, 12, 18]
+
+    def download_forecast(
+        self,
+        target_date: dt.date | str,
+        forecast_hour: int,
+    ) -> dict[Literal["downloaded", "skipped", "failed", "size_mb"], int | float]:
+        """
+        Download GFS forecast for a specific date and hour.
+
+        Args:
+            target_date: Target date (YYYY-MM-DD string or date object)
+            forecast_hour: Forecast cycle hour (0, 6, 12, or 18)
+
+        Returns:
+            Dictionary with download statistics
+        """
+        # Parse date
+        if isinstance(target_date, str):
+            target_date = dt.datetime.strptime(target_date, "%Y-%m-%d").date()
+
+        # Build NOMADS URL
+        forecast_time = target_date.strftime("%Y%m%d")
+        url = self._build_nomads_url(forecast_time, forecast_hour)
+
+        # Output filename: YYYYMMDD-HH.grib2
+        # This matches what forecast command expects (line 970 in cli/__init__.py)
+        dest_fname = f"{forecast_time}-{forecast_hour:02d}.grib2"
+        dest_path = self.forecasts_dir / dest_fname
+
+        # Check if already exists and is valid
+        if dest_path.exists() and dest_path.stat().st_size > self.min_file_size:
+            return {"downloaded": 0, "skipped": 1, "failed": 0, "size_mb": 0}
+
+        # Download
+        try:
+            size_mb = self._download_with_retry(url, dest_path)
+            return {"downloaded": 1, "skipped": 0, "failed": 0, "size_mb": size_mb}
+        except Exception as e:
+            # Remove partial file
+            if dest_path.exists():
+                dest_path.unlink()
+            return {"downloaded": 0, "skipped": 0, "failed": 1, "size_mb": 0}
+
+    def download_day(
+        self,
+        target_date: dt.date | str,
+    ) -> dict[str, int | float]:
+        """
+        Download all forecast hours for a target date.
+
+        This matches the forecast command's expectation (line 969-970 in cli/__init__.py).
+
+        Args:
+            target_date: Target date (YYYY-MM-DD string or date object)
+
+        Returns:
+            Dictionary with aggregated statistics
+        """
+        if isinstance(target_date, str):
+            target_date = dt.datetime.strptime(target_date, "%Y-%m-%d").date()
+
+        stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
+
+        for hour in self.forecast_hours:
+            result = self.download_forecast(target_date, hour)
+            stats["downloaded"] += result["downloaded"]
+            stats["skipped"] += result["skipped"]
+            stats["failed"] += result["failed"]
+            stats["total_mb"] += result["size_mb"]
+
+        return stats
+
+    def _build_nomads_url(self, forecast_time: str, forecast_hour: int) -> str:
+        """
+        Build NOMADS filter API URL for GFS forecast download.
+
+        Matches the URL pattern from legacy code (neural_network/forecast.py:129).
+
+        Format:
+        https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl?file=gfs.tHHz.pgrb2.0p25.f000&...&dir=%2Fgfs.YYYYMMDD%2Fatmos
+
+        Args:
+            forecast_time: Forecast date as YYYYMMDD string
+            forecast_hour: Forecast cycle hour (0, 6, 12, 18)
+
+        Returns:
+            Complete NOMADS API URL
+        """
+        # Base URL
+        base_url = f"https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_{self.GRID}.pl"
+
+        # File parameter: gfs.tHHz.pgrb2.0p25.f000
+        # f000 = analysis time (start of forecast cycle)
+        file_param = f"file=gfs.t{forecast_hour:02d}z.pgrb2.{self.GRID}.f000"
+
+        # Level and variable parameters (from legacy GfsData)
+        levels_param = "&".join(self._FORECAST_LEVELS)
+        vars_param = "&".join(self._FORECAST_VARS)
+
+        # Directory parameter: %2Fgfs.YYYYMMDD%2FHH
+        # %2F is URL-encoded /
+        dir_param = f"dir=%2Fgfs.{forecast_time}%2F{forecast_hour:02d}"
+
+        # Spatial coverage (global)
+        region_param = "leftlon=0&rightlon=360&toplat=90&bottomlat=-90"
+
+        # Full URL
+        url = f"{base_url}?{file_param}&{levels_param}&{vars_param}&{region_param}&{dir_param}"
+
+        return url
+
+    def _download_with_retry(self, url: str, dest_path: Path) -> float:
+        """
+        Download with retry logic.
+
+        Args:
+            url: URL to download from
+            dest_path: Destination file path
+
+        Returns:
+            Size in MB
+
+        Raises:
+            RuntimeError: If all retry attempts fail
+        """
+        last_error = None
+
+        for attempt in range(self.max_retries):
+            try:
+                # Stream download with progress
+                with tqdm(
+                    desc=f"  {dest_path.name}",
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=1024 * 1024,
+                ) as pbar:
+                    req = urllib.request.Request(url)
+                    with urllib.request.urlopen(req, timeout=60) as response:
+                        with open(dest_path, "wb") as f:
+                            while True:
+                                chunk = response.read(131072)  # 128KB chunks
+                                if not chunk:
+                                    break
+                                f.write(chunk)
+                                pbar.update(len(chunk))
+
+                # Verify file size
+                if dest_path.stat().st_size < self.min_file_size:
+                    raise RuntimeError(f"Downloaded file too small: {dest_path.stat().st_size} bytes")
+
+                size_mb = dest_path.stat().st_size / (1024 * 1024)
+                return size_mb
+
+            except (urllib.error.URLError, urllib.error.HTTPError) as e:
+                last_error = e
+                if attempt < self.max_retries - 1:
+                    import time
+
+                    wait_time = 2**attempt
+                    time.sleep(wait_time)
+                else:
+                    raise RuntimeError(f"Failed after {self.max_retries} attempts: {e}") from e
+            except Exception:
+                raise
+
+        raise RuntimeError(f"Failed after {self.max_retries} attempts") from last_error

--- a/tests/test_gfs_forecast_downloader.py
+++ b/tests/test_gfs_forecast_downloader.py
@@ -1,0 +1,137 @@
+"""Tests for GFS Forecast downloader."""
+
+import datetime as dt
+
+import pytest
+
+from pyparaglide.downloads.gfs_forecast_downloader import GFSForecastDownloader
+
+
+class TestGFSForecastDownloader:
+    """Test GFS Forecast downloader URL building and file naming."""
+
+    def test_nomads_url_construction(self):
+        """Test NOMADS URL is built correctly."""
+        downloader = GFSForecastDownloader(".")
+
+        url = downloader._build_nomads_url("20250104", 0)
+
+        assert "filter_gfs_0p25.pl" in url
+        assert "file=gfs.t00z.pgrb2.0p25.f000" in url
+        assert "dir=%2Fgfs.20250104%2F00" in url
+        assert "var_TMP=on" in url
+        assert "var_UGRD=on" in url
+        assert "var_VGRD=on" in url
+        assert "lev_700_mb=on" in url
+        assert "lev_1000_mb=on" in url
+
+    def test_forecast_filename_format(self):
+        """Test forecast file naming matches forecast command expectation."""
+        downloader = GFSForecastDownloader(".")
+
+        # forecast command expects f"{date.strftime('%Y%m%d')}-{hour:02d}.grib2"
+        # See cli/__init__.py line 970
+        date = dt.date(2025, 1, 4)
+        hour = 6
+
+        fname = f"{date.strftime('%Y%m%d')}-{hour:02d}.grib2"
+        assert fname == "20250104-06.grib2"
+
+        # Verify this matches what the downloader would create
+        expected_path = downloader.forecasts_dir / fname
+        assert expected_path.name == "20250104-06.grib2"
+
+    def test_forecast_hours_default(self):
+        """Test default forecast hours match forecast command expectation."""
+        downloader = GFSForecastDownloader(".")
+
+        # forecast command expects [6, 12, 18]
+        # See cli/__init__.py line 969
+        assert downloader.forecast_hours == [6, 12, 18]
+
+    @pytest.mark.parametrize(
+        "date_str,expected", [("2025-01-04", "20250104"), ("2024-12-31", "20241231")]
+    )
+    def test_date_parsing(self, date_str, expected):
+        """Test date string parsing."""
+        parsed = dt.datetime.strptime(date_str, "%Y-%m-%d").date()
+        forecast_time = parsed.strftime("%Y%m%d")
+
+        assert forecast_time == expected
+
+    def test_forecasts_dir_creation(self, tmp_path):
+        """Test that forecasts directory is created."""
+        downloader = GFSForecastDownloader(tmp_path)
+
+        assert downloader.forecasts_dir.exists()
+        assert downloader.forecasts_dir.name == "forecasts"
+
+    def test_nomads_url_different_hours(self):
+        """Test NOMADS URL for different forecast hours."""
+        downloader = GFSForecastDownloader(".")
+
+        url_00 = downloader._build_nomads_url("20250104", 0)
+        url_06 = downloader._build_nomads_url("20250104", 6)
+        url_12 = downloader._build_nomads_url("20250104", 12)
+        url_18 = downloader._build_nomads_url("20250104", 18)
+
+        assert "file=gfs.t00z.pgrb2.0p25.f000" in url_00
+        assert "dir=%2Fgfs.20250104%2F00" in url_00
+
+        assert "file=gfs.t06z.pgrb2.0p25.f000" in url_06
+        assert "dir=%2Fgfs.20250104%2F06" in url_06
+
+        assert "file=gfs.t12z.pgrb2.0p25.f000" in url_12
+        assert "dir=%2Fgfs.20250104%2F12" in url_12
+
+        assert "file=gfs.t18z.pgrb2.0p25.f000" in url_18
+        assert "dir=%2Fgfs.20250104%2F18" in url_18
+
+    def test_nomads_url_contains_all_required_vars(self):
+        """Test that NOMADS URL contains all required weather variables."""
+        downloader = GFSForecastDownloader(".")
+        url = downloader._build_nomads_url("20250104", 0)
+
+        # Temperature
+        assert "var_TMP=on" in url
+
+        # Wind components
+        assert "var_UGRD=on" in url
+        assert "var_VGRD=on" in url
+
+        # Humidity
+        assert "var_RH=on" in url
+
+        # Precipitable water
+        assert "var_PWAT=on" in url
+
+        # Cloud water
+        assert "var_CWAT=on" in url
+
+        # Geopotential height
+        assert "var_HGT=on" in url
+
+        # Vertical velocity
+        assert "var_VVEL=on" in url
+
+        # Absolute vorticity
+        assert "var_ABSV=on" in url
+
+    def test_nomads_url_contains_all_required_levels(self):
+        """Test that NOMADS URL contains all required pressure levels."""
+        downloader = GFSForecastDownloader(".")
+        url = downloader._build_nomads_url("20250104", 0)
+
+        # Pressure levels
+        assert "lev_200_mb=on" in url
+        assert "lev_300_mb=on" in url
+        assert "lev_400_mb=on" in url
+        assert "lev_500_mb=on" in url
+        assert "lev_600_mb=on" in url
+        assert "lev_700_mb=on" in url
+        assert "lev_800_mb=on" in url
+        assert "lev_900_mb=on" in url
+        assert "lev_1000_mb=on" in url
+
+        # Entire atmosphere
+        assert "lev_entire_atmosphere=on" in url


### PR DESCRIPTION
## Summary

- Add `pyparaglide dl` subcommands for better data management
- Add `GFSForecastDownloader` for downloading GFS Forecast from NOMADS API
- Refactor existing `download` command to use shared helper functions
- Maintain backward compatibility with original `pyparaglide download` command

## New Commands

```bash
# New subcommands
pyparaglide dl analysis --dates 2024-06-01:2024-08-31  # GFS Analysis
pyparaglide dl forecast --date 2025-01-04                # GFS Forecast
pyparaglide dl elevation                                 # SRTM elevation

# Legacy (still works)
pyparaglide download --dates 2024-06-01:2024-08-31
```

## Changes

### New Files
- `src/pyparaglide/downloads/gfs_forecast_downloader.py` - NOMADS API downloader
- `src/pyparaglide/cli/_download_helpers.py` - Shared download logic
- `tests/test_gfs_forecast_downloader.py` - Unit tests

### Modified Files
- `src/pyparaglide/cli/__init__.py` - Add `dl` subcommand group
- `src/pyparaglide/downloads/__init__.py` - Export `GFSForecastDownloader`
- `src/pyparaglide/downloads/gfs_downloader.py` - Fix return type annotation

## NOMADS URL Pattern

Uses NOMADS filter API matching legacy code:
```
https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl?
  file=gfs.t00z.pgrb2.0p25.f000
  &lev_700_mb=on&lev_850_mb=on...
  &var_TMP=on&var_UGRD=on&var_VGRD=on...
  &dir=%2Fgfs.20250104%2F00
```

## File Naming

Forecast files: `YYYYMMDD-HH.grib2` (e.g., `20250104-06.grib2`)
Saved to: `{gfs_dir}/forecasts/`

Closes #25