### PR TITLE
fix: correct forecast download with day offset and --force flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,26 +129,36 @@ pyparaglide forecast
 | `pyparaglide version` | Show version information |
 | `pyparaglide config` | Show current configuration |
 | `pyparaglide info` | Show system information |
-| `pyparaglide download` | Download GFS weather data |
+| `pyparaglide download` | Download GFS analysis + elevation (legacy) |
+| `pyparaglide dl analysis` | Download GFS analysis data (historical) |
+| `pyparaglide dl forecast` | Download GFS forecast data (predictions) |
+| `pyparaglide dl elevation` | Download SRTM elevation data |
 | `pyparaglide build-dataset` | Build PKL dataset from GRIB + flights |
 | `pyparaglide analyze` | Analyze flights and weather data |
 | `pyparaglide train` | Train neural network model |
 | `pyparaglide forecast` | Generate flyability forecast |
 
-### Example: Data Download
+### Data Download
+
+#### GFS Analysis Data (Historical Weather)
+
+GFS Analysis data is historical weather data used for **training** models:
 
 ```bash
 # Use dates from .env (TRAINING_DATES)
-pyparaglide download
+pyparaglide dl analysis
 
 # Single range
-pyparaglide download --dates 2024-06-01:2024-08-31
+pyparaglide dl analysis --dates 2024-06-01:2024-08-31
 
 # Multiple ranges
-pyparaglide download --dates "2024-06-01:2024-08-31,2025-06-01:2025-08-31"
+pyparaglide dl analysis --dates "2024-06-01:2024-08-31,2025-06-01:2025-08-31"
 
-# With parallel downloads
-pyparaglide download --dates 2024-06-01:2024-08-31 --workers 4 --filter
+# Legacy format (single range)
+pyparaglide dl analysis --start 2024-06-01 --end 2024-08-31
+
+# With parallel downloads and filtering
+pyparaglide dl analysis --dates 2024-06-01:2024-08-31 --workers 4 --filter
 ```
 
 **Date Format Priority:**
@@ -156,26 +166,74 @@ pyparaglide download --dates 2024-06-01:2024-08-31 --workers 4 --filter
 2. `--start/--end` (legacy format, single range)
 3. `.env` TRAINING_DATES (default)
 
+#### GFS Forecast Data (Predictions)
+
+GFS Forecast data is used for **generating predictions**:
+
+```bash
+# Download next 10 days from latest forecast run (default)
+pyparaglide dl forecast --days 10
+
+# Download for specific date
+pyparaglide dl forecast --date 2026-01-05
+
+# Download for date range
+pyparaglide dl forecast --start 2026-01-05 --end 2026-01-15
+
+# Force re-download (overwrite existing files)
+pyparaglide dl forecast --days 10 --force
+```
+
+**How it works:**
+- Automatically finds the latest available GFS forecast run from NOMADS
+- Calculates correct forecast offsets (f006, f012, f018, etc.)
+- Downloads for 3 hours per day: 06:00, 12:00, 18:00 UTC
+- Files are named by **valid time**: `YYYYMMDD-HH.grib2`
+
+#### Elevation Data
+
+```bash
+# Download SRTM elevation data (uses BBOX from .env)
+pyparaglide dl elevation
+
+# Download with custom bbox
+pyparaglide dl elevation --bbox 45,47,13,15
+```
+
+#### Legacy Command (Backward Compatible)
+
+```bash
+# Legacy flat command (downloads analysis + elevation)
+pyparaglide download --dates 2024-06-01:2024-08-31
+```
+
 ### Example: Training
 
 ```bash
-# Train with 10 cells for 55 epochs
-pyparaglide train --cell 10 --epochs 55 --batch-size 32
+# Train SPOTS model for cell 10 with 55 epochs
+pyparaglide train -m spots --cell 10 --epochs 55 --batch-size 32
+
+# Train CELLS model (all cells at once)
+pyparaglide train -m cells --epochs 55
 
 # Train with specific learning rate
-pyparaglide train --cell 5 --lr-init 0.01 --lr-end 0.001
+pyparaglide train -m spots --cell 5 --lr-init 0.01 --lr-end 0.001
+
+# Train multiple cells
+pyparaglide train -m spots --cell 0,1,2,3,4 --epochs 55
 
 # Train without validation
-pyparaglide train --cell 10 --no-validation
+pyparaglide train -m spots --cell 10 --no-validation
 ```
 
 ### Example: Forecast
 
 ```bash
-# Generate 10-day forecast (default)
+# Generate forecast (requires GFS forecast data in data/gfs/forecasts/)
 pyparaglide forecast
 
-# Generate with custom output directory
+# Generate for specific date
+pyparaglide forecast --date 2026-01-05
 pyparaglide forecast --output-dir /path/to/output
 
 # Show debug information
@@ -305,9 +363,41 @@ mypy src/
 
 ### Weather Data (GFS)
 
-PyParaglide uses NOAA GFS (Global Forecast System) weather data:
-- **GFS Analysis** (2021+): AWS S3 (NOAA Open Data)
-- **GFS Analysis** (2000-2021): NCAR RDA (requires free registration)
+PyParaglide uses NOAA GFS (Global Forecast System) weather data from two sources:
+
+#### GFS Analysis (Historical - for Training)
+
+GFS Analysis is **historical weather data** used for **training** models:
+
+| Source | Years | Access | Download Command |
+|--------|-------|--------|------------------|
+| AWS S3 (NOAA Open Data) | 2021+ | Public, free | `pyparaglide dl analysis` |
+| NCAR RDA | 2000-2021 | Requires free registration | Manual download required |
+
+**Usage:** Train models with historical flight data
+```bash
+pyparaglide dl analysis --dates 2024-06-01:2024-08-31
+```
+
+#### GFS Forecast (Predictions - for Forecasting)
+
+GFS Forecast is **future weather prediction** used for **generating forecasts**:
+
+| Source | Latency | Access | Download Command |
+|--------|---------|--------|------------------|
+| NOMADS API | ~6 hours | Public, free | `pyparaglide dl forecast` |
+
+**Usage:** Generate flyability predictions for upcoming days
+```bash
+# Download next 10 days from latest GFS run
+pyparaglide dl forecast --days 10
+```
+
+**How it works:**
+- NOMADS provides GFS forecast runs 4 times daily (00, 06, 12, 18 UTC)
+- Each run contains predictions up to 16 days ahead (f000 to f384)
+- PyParaglide automatically finds the latest run and calculates correct offsets
+- Downloads 3 forecast hours per day: 06:00, 12:00, 18:00 UTC
 
 ### Elevation Data (SRTM)
 

--- a/src/pyparaglide/cli/__init__.py
+++ b/src/pyparaglide/cli/__init__.py
@@ -457,19 +457,29 @@ def download_analysis(
 
 @download_app.command("forecast")
 def download_forecast(
-    date: str = typer.Option(..., "--date", "-d", help="Target date (YYYY-MM-DD)"),
+    days: int = typer.Option(10, "--days", "-D", help="Number of days ahead to download from latest forecast run"),
+    date: str = typer.Option(None, "--date", "-d", help="Specific target date (YYYY-MM-DD)"),
+    start_date: str = typer.Option(None, "--start", "-s", help="Start date (YYYY-MM-DD)"),
+    end_date: str = typer.Option(None, "--end", "-e", help="End date (YYYY-MM-DD)"),
     data_dir: str = typer.Option(None, "--data-dir", "-o", help="Output directory for GRIB files"),
     hours: str = typer.Option("6,12,18", "--hours", "-H", help="Forecast hours to download (comma-separated)"),
+    force: bool = typer.Option(False, "--force", "-f", help="Redownload existing files"),
 ) -> None:
     """
     Download GFS Forecast data (for generating predictions).
 
     Downloads GFS Forecast GRIB files from NOMADS for generating flyability predictions.
-    Files are saved as YYYYMMDD-HH.grib2 in the forecasts subdirectory.
+    Automatically finds the best available forecast run and uses correct forecast offsets.
+
+    MODES:
+    1. --days N   : Download N days ahead from latest forecast run (default)
+    2. --date D   : Download forecast for specific date
+    3. --start S --end E : Download for date range
 
     Examples:
-        pyparaglide download forecast --date 2025-01-04
-        pyparaglide download forecast --date 2025-01-04 --hours 6,12,18
+        pyparaglide dl forecast --days 10
+        pyparaglide dl forecast --date 2026-01-05
+        pyparaglide dl forecast --start 2026-01-05 --end 2026-01-15
     """
     import datetime as dt
 
@@ -478,29 +488,77 @@ def download_forecast(
     if data_dir is None:
         data_dir = settings.gfs_dir
 
-    # Parse target date
-    try:
-        target_date = dt.datetime.strptime(date, "%Y-%m-%d").date()
-    except ValueError:
-        console.print(f"[red]Invalid date format: {date}[/red]")
-        console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
-        raise typer.Exit(1)
-
-    console.print(f"[bold cyan]Downloading GFS Forecast data[/bold cyan]")
-    console.print(f"[dim]Date: {target_date.isoformat()}[/dim]")
-    console.print(f"[dim]Hours: {hours}[/dim]\n")
-
-    # Create downloader
-    downloader = GFSForecastDownloader(
-        data_dir=data_dir,
-    )
-
     # Parse hours
     hour_list = [int(h.strip()) for h in hours.split(",")]
+
+    # Create downloader
+    downloader = GFSForecastDownloader(data_dir=data_dir)
     downloader.forecast_hours = hour_list
 
-    # Download
-    stats = downloader.download_day(target_date)
+    # Determine download mode
+    if date:
+        # Single date mode
+        if start_date or end_date:
+            console.print("[red]Error: --date cannot be used with --start/--end[/red]")
+            raise typer.Exit(1)
+
+        try:
+            target_date = dt.datetime.strptime(date, "%Y-%m-%d").date()
+        except ValueError:
+            console.print(f"[red]Invalid date format: {date}[/red]")
+            console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
+            raise typer.Exit(1)
+
+        console.print(f"[bold cyan]Downloading GFS Forecast data[/bold cyan]\n")
+        console.print(f"[dim]Mode: Single date[/dim]")
+        console.print(f"[dim]Date: {target_date.isoformat()}[/dim]")
+        console.print(f"[dim]Hours: {hours}[/dim]")
+        if force:
+            console.print(f"[dim]Force: Enabled (will re-download existing files)[/dim]")
+        console.print()
+
+        stats = downloader.download_day(target_date, force=force)
+
+    elif start_date and end_date:
+        # Date range mode
+        try:
+            start = dt.datetime.strptime(start_date, "%Y-%m-%d").date()
+            end = dt.datetime.strptime(end_date, "%Y-%m-%d").date()
+        except ValueError:
+            console.print("[red]Invalid date format[/red]")
+            console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
+            raise typer.Exit(1)
+
+        console.print(f"[bold cyan]Downloading GFS Forecast data[/bold cyan]\n")
+        console.print(f"[dim]Mode: Date range[/dim]")
+        console.print(f"[dim]Range: {start.isoformat()} to {end.isoformat()}[/dim]")
+        console.print(f"[dim]Hours: {hours}[/dim]")
+        if force:
+            console.print(f"[dim]Force: Enabled (will re-download existing files)[/dim]")
+        console.print()
+
+        stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
+
+        current = start
+        while current <= end:
+            day_stats = downloader.download_day(current, force=force)
+            stats["downloaded"] += day_stats["downloaded"]
+            stats["skipped"] += day_stats["skipped"]
+            stats["failed"] += day_stats["failed"]
+            stats["total_mb"] += day_stats["total_mb"]
+            current += dt.timedelta(days=1)
+
+    else:
+        # Days ahead mode (default)
+        console.print(f"[bold cyan]Downloading GFS Forecast data[/bold cyan]\n")
+        console.print(f"[dim]Mode: Days ahead from latest run[/dim]")
+        console.print(f"[dim]Days: {days}[/dim]")
+        console.print(f"[dim]Hours: {hours}[/dim]")
+        if force:
+            console.print(f"[dim]Force: Enabled (will re-download existing files)[/dim]")
+        console.print()
+
+        stats = downloader.download_days_ahead(days=days, force=force)
 
     # Print summary
     console.print(f"\n[bold]Download Summary:[/bold]")

--- a/src/pyparaglide/downloads/gfs_forecast_downloader.py
+++ b/src/pyparaglide/downloads/gfs_forecast_downloader.py
@@ -6,6 +6,7 @@ Uses NOMADS filter API for targeted parameter downloads.
 """
 
 import datetime as dt
+import re
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -82,13 +83,18 @@ class GFSForecastDownloader:
         self,
         target_date: dt.date | str,
         forecast_hour: int,
+        force: bool = False,
     ) -> dict[Literal["downloaded", "skipped", "failed", "size_mb"], int | float]:
         """
         Download GFS forecast for a specific date and hour.
 
+        For future dates, automatically finds the best available forecast run
+        and uses the correct forecast offset (f006, f012, etc.).
+
         Args:
             target_date: Target date (YYYY-MM-DD string or date object)
-            forecast_hour: Forecast cycle hour (0, 6, 12, or 18)
+            forecast_hour: Forecast hour (6, 12, or 18)
+            force: Force re-download even if file exists
 
         Returns:
             Dictionary with download statistics
@@ -97,32 +103,54 @@ class GFSForecastDownloader:
         if isinstance(target_date, str):
             target_date = dt.datetime.strptime(target_date, "%Y-%m-%d").date()
 
-        # Build NOMADS URL
-        forecast_time = target_date.strftime("%Y%m%d")
-        url = self._build_nomads_url(forecast_time, forecast_hour)
+        target_datetime = dt.datetime.combine(target_date, dt.time(forecast_hour, 0))
 
-        # Output filename: YYYYMMDD-HH.grib2
-        # This matches what forecast command expects (line 970 in cli/__init__.py)
-        dest_fname = f"{forecast_time}-{forecast_hour:02d}.grib2"
+        # Output filename: YYYYMMDD-HH.grib2 (matches forecast command expectation)
+        dest_fname = f"{target_date.strftime('%Y%m%d')}-{forecast_hour:02d}.grib2"
         dest_path = self.forecasts_dir / dest_fname
 
         # Check if already exists and is valid
-        if dest_path.exists() and dest_path.stat().st_size > self.min_file_size:
+        if not force and dest_path.exists() and dest_path.stat().st_size > self.min_file_size:
             return {"downloaded": 0, "skipped": 1, "failed": 0, "size_mb": 0}
 
-        # Download
-        try:
-            size_mb = self._download_with_retry(url, dest_path)
-            return {"downloaded": 1, "skipped": 0, "failed": 0, "size_mb": size_mb}
-        except Exception as e:
-            # Remove partial file
-            if dest_path.exists():
-                dest_path.unlink()
-            return {"downloaded": 0, "skipped": 0, "failed": 1, "size_mb": 0}
+        # Get available forecast runs from NOMADS
+        available_runs = self._get_available_forecast_runs(limit=8)
+
+        # Find the best forecast run for this target time
+        last_error = None
+
+        for run_str in available_runs:
+            # Parse run time: YYYYMMDDHH
+            run_datetime = dt.datetime.strptime(run_str, "%Y%m%d%H")
+
+            # Calculate offset from run time to target time
+            offset_hours = int((target_datetime - run_datetime).total_seconds() / 3600)
+
+            # Check if this run can provide forecast for target time
+            # GFS forecasts go up to 16 days = 384 hours
+            if 0 <= offset_hours <= 384:
+                try:
+                    url, _ = self._build_nomads_url_with_offset(run_str, offset_hours)
+                    size_mb = self._download_with_retry(url, dest_path)
+                    return {"downloaded": 1, "skipped": 0, "failed": 0, "size_mb": size_mb}
+                except Exception as e:
+                    last_error = e
+                    # Try next available run
+                    continue
+
+        # All attempts failed
+        if dest_path.exists():
+            dest_path.unlink()
+
+        error_msg = f"Failed to download forecast for {target_date} {forecast_hour:02d}Z"
+        if last_error:
+            error_msg += f": {last_error}"
+        return {"downloaded": 0, "skipped": 0, "failed": 1, "size_mb": 0}
 
     def download_day(
         self,
         target_date: dt.date | str,
+        force: bool = False,
     ) -> dict[str, int | float]:
         """
         Download all forecast hours for a target date.
@@ -131,6 +159,7 @@ class GFSForecastDownloader:
 
         Args:
             target_date: Target date (YYYY-MM-DD string or date object)
+            force: Force re-download even if file exists
 
         Returns:
             Dictionary with aggregated statistics
@@ -141,11 +170,97 @@ class GFSForecastDownloader:
         stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
 
         for hour in self.forecast_hours:
-            result = self.download_forecast(target_date, hour)
+            result = self.download_forecast(target_date, hour, force=force)
             stats["downloaded"] += result["downloaded"]
             stats["skipped"] += result["skipped"]
             stats["failed"] += result["failed"]
             stats["total_mb"] += result["size_mb"]
+
+        return stats
+
+    def download_days_ahead(
+        self,
+        days: int = 10,
+        run_date: dt.date | str | None = None,
+        force: bool = False,
+    ) -> dict[str, int | float]:
+        """
+        Download forecast for N days ahead from latest (or specified) forecast run.
+
+        This matches the legacy forecast.py behavior which downloads for days=0..9
+        from the last available forecast run.
+
+        Args:
+            days: Number of days to download (default 10)
+            run_date: Specific forecast run date to use (auto-detect if None)
+            force: Force re-download even if file exists
+
+        Returns:
+            Dictionary with aggregated statistics
+        """
+        # Get available forecast runs
+        available_runs = self._get_available_forecast_runs(limit=4)
+
+        if run_date is None:
+            # Use the most recent run
+            run_str = available_runs[0]
+        else:
+            # Find the specified run
+            if isinstance(run_date, str):
+                run_date = dt.datetime.strptime(run_date, "%Y-%m-%d").date()
+
+            run_str = None
+            for rs in available_runs:
+                run_dt = dt.datetime.strptime(rs, "%Y%m%d%H").date()
+                if run_dt == run_date:
+                    run_str = rs
+                    break
+
+            if run_str is None:
+                raise ValueError(f"Forecast run for {run_date} not found in available runs")
+
+        # Parse run datetime
+        run_datetime = dt.datetime.strptime(run_str, "%Y%m%d%H")
+
+        stats = {"downloaded": 0, "skipped": 0, "failed": 0, "total_mb": 0.0}
+
+        # Download for each day and hour
+        for day_offset in range(days):
+            target_date = run_datetime.date() + dt.timedelta(days=day_offset)
+
+            for target_hour in self.forecast_hours:
+                target_datetime = dt.datetime.combine(target_date, dt.time(target_hour, 0))
+
+                # Calculate forecast offset
+                offset_hours = int((target_datetime - run_datetime).total_seconds() / 3600)
+
+                # Skip if offset is negative (target is before run)
+                if offset_hours < 0:
+                    continue
+
+                # Skip if beyond GFS forecast range
+                if offset_hours > 384:
+                    continue
+
+                # Output filename
+                dest_fname = f"{target_date.strftime('%Y%m%d')}-{target_hour:02d}.grib2"
+                dest_path = self.forecasts_dir / dest_fname
+
+                # Check if already exists
+                if not force and dest_path.exists() and dest_path.stat().st_size > self.min_file_size:
+                    stats["skipped"] += 1
+                    continue
+
+                # Download
+                try:
+                    url, _ = self._build_nomads_url_with_offset(run_str, offset_hours)
+                    size_mb = self._download_with_retry(url, dest_path)
+                    stats["downloaded"] += 1
+                    stats["total_mb"] += size_mb
+                except Exception:
+                    if dest_path.exists():
+                        dest_path.unlink()
+                    stats["failed"] += 1
 
         return stats
 
@@ -188,6 +303,103 @@ class GFSForecastDownloader:
 
         return url
 
+    def _get_available_forecast_runs(self, limit: int = 4) -> list[str]:
+        """
+        Scrape NOMADS to find last available forecast runs.
+
+        Matches legacy behavior from neural_network/forecast.py:108-123.
+
+        Args:
+            limit: Maximum number of runs to return (default 4)
+
+        Returns:
+            List of forecast run strings like ["2026010418", "2026010412", ...]
+            Format: YYYYMMDDHH (date + hour of forecast run)
+        """
+        base_url = f"https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_{self.GRID}.pl"
+
+        try:
+            # Get list of available forecast dates
+            with urllib.request.urlopen(base_url, timeout=30) as response:
+                html = response.read().decode('utf-8')
+
+            # Parse forecast dates from HTML links
+            # Pattern: ">gfs.YYYYMMDD</a>"
+            forecast_dates = re.findall(r'">gfs\.([0-9]+)</a>', html)
+
+            if not forecast_dates:
+                raise RuntimeError(f"No forecast dates found on NOMADS")
+
+            runs: list[str] = []
+
+            # Check last 2 dates for available hours
+            for date_str in forecast_dates[:2]:
+                dir_url = f"{base_url}?dir=%2Fgfs.{date_str}"
+                try:
+                    with urllib.request.urlopen(dir_url, timeout=30) as response:
+                        html2 = response.read().decode('utf-8')
+
+                    # Parse forecast hours from directory listing
+                    # Pattern: "gfs.YYYYMMDD%2FHH"
+                    hours = re.findall(f'gfs\\.{date_str}%2F([0-9]{{2}})', html2)
+
+                    # Combine date + hour
+                    for hour in hours:
+                        runs.append(f"{date_str}{hour}")
+
+                except urllib.error.URLError:
+                    continue
+
+            if not runs:
+                raise RuntimeError(f"No forecast runs found on NOMADS")
+
+            return runs[:limit]
+
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Failed to fetch available forecast runs: {e}") from e
+
+    def _build_nomads_url_with_offset(
+        self,
+        run_time_str: str,
+        forecast_offset: int,
+    ) -> tuple[str, dt.datetime]:
+        """
+        Build NOMADS URL with forecast offset (f000, f006, f012, etc.).
+
+        Args:
+            run_time_str: Forecast run time as YYYYMMDDHH string
+            forecast_offset: Hours into the forecast (0, 6, 12, ..., 384)
+
+        Returns:
+            Tuple of (complete URL, forecast run datetime)
+
+        Example:
+            run_time_str="2026010418", offset=12
+            -> URL with f012, run_datetime=2026-01-04 18:00
+        """
+        # Parse run time: YYYYMMDDHH
+        run_date = dt.datetime.strptime(run_time_str, "%Y%m%d%H")
+
+        # File parameter: gfs.tHHz.pgrb2.0p25.fOFFSET
+        file_param = f"file=gfs.t{run_date.hour:02d}z.pgrb2.{self.GRID}.f{forecast_offset:03d}"
+
+        # Level and variable parameters
+        levels_param = "&".join(self._FORECAST_LEVELS)
+        vars_param = "&".join(self._FORECAST_VARS)
+
+        # Directory parameter: %2Fgfs.YYYYMMDD%2FHH%2Fatmos
+        # Format: /gfs.20260104/12/atmos (date + hour + atmos)
+        dir_param = f"dir=%2Fgfs.{run_date.strftime('%Y%m%d')}%2F{run_date.hour:02d}%2Fatmos"
+
+        # Spatial coverage (global)
+        region_param = "leftlon=0&rightlon=360&toplat=90&bottomlat=-90"
+
+        # Full URL
+        base_url = f"https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_{self.GRID}.pl"
+        url = f"{base_url}?{file_param}&{levels_param}&{vars_param}&{region_param}&{dir_param}"
+
+        return url, run_date
+
     def _download_with_retry(self, url: str, dest_path: Path) -> float:
         """
         Download with retry logic.
@@ -211,7 +423,6 @@ class GFSForecastDownloader:
                     desc=f"  {dest_path.name}",
                     unit="B",
                     unit_scale=True,
-                    unit_divisor=1024 * 1024,
                 ) as pbar:
                     req = urllib.request.Request(url)
                     with urllib.request.urlopen(req, timeout=60) as response:

--- a/tests/test_gfs_forecast_downloader.py
+++ b/tests/test_gfs_forecast_downloader.py
@@ -11,7 +11,7 @@ class TestGFSForecastDownloader:
     """Test GFS Forecast downloader URL building and file naming."""
 
     def test_nomads_url_construction(self):
-        """Test NOMADS URL is built correctly."""
+        """Test NOMADS URL is built correctly (legacy method with f000)."""
         downloader = GFSForecastDownloader(".")
 
         url = downloader._build_nomads_url("20250104", 0)
@@ -25,12 +25,57 @@ class TestGFSForecastDownloader:
         assert "lev_700_mb=on" in url
         assert "lev_1000_mb=on" in url
 
+    def test_nomads_url_with_offset(self):
+        """Test NOMADS URL with forecast offset (f006, f012, etc.)."""
+        downloader = GFSForecastDownloader(".")
+
+        # Test various offsets
+        url_f000, run_dt = downloader._build_nomads_url_with_offset("2026010418", 0)
+        assert "file=gfs.t18z.pgrb2.0p25.f000" in url_f000
+        assert "dir=%2Fgfs.20260104%2F18%2Fatmos" in url_f000
+        assert run_dt == dt.datetime(2026, 1, 4, 18, 0)
+
+        url_f006, _ = downloader._build_nomads_url_with_offset("2026010418", 6)
+        assert "file=gfs.t18z.pgrb2.0p25.f006" in url_f006
+        assert "dir=%2Fgfs.20260104%2F18%2Fatmos" in url_f006
+
+        url_f012, _ = downloader._build_nomads_url_with_offset("2026010418", 12)
+        assert "file=gfs.t18z.pgrb2.0p25.f012" in url_f012
+        assert "dir=%2Fgfs.20260104%2F18%2Fatmos" in url_f012
+
+        url_f030, _ = downloader._build_nomads_url_with_offset("2026010418", 30)
+        assert "file=gfs.t18z.pgrb2.0p25.f030" in url_f030
+
+        url_f384, _ = downloader._build_nomads_url_with_offset("2026010418", 384)
+        assert "file=gfs.t18z.pgrb2.0p25.f384" in url_f384
+
+    def test_forecast_offset_calculation(self):
+        """Test forecast offset calculation for target date."""
+        # Example: forecast run on Jan 4, 18:00 UTC
+        # Target: Jan 5, 06:00 UTC
+        # Offset = 12 hours (f012)
+        run_datetime = dt.datetime(2026, 1, 4, 18, 0)
+        target_datetime = dt.datetime(2026, 1, 5, 6, 0)
+
+        offset_hours = int((target_datetime - run_datetime).total_seconds() / 3600)
+        assert offset_hours == 12
+
+        # Same day, 06:00 (from 18:00 run - not possible, would be negative)
+        target_same_day = dt.datetime(2026, 1, 4, 6, 0)
+        offset_same = int((target_same_day - run_datetime).total_seconds() / 3600)
+        assert offset_same == -12  # Would need previous run
+
+        # Next day, 18:00 (from 18:00 run)
+        target_next_day = dt.datetime(2026, 1, 5, 18, 0)
+        offset_next = int((target_next_day - run_datetime).total_seconds() / 3600)
+        assert offset_next == 24
+
     def test_forecast_filename_format(self):
         """Test forecast file naming matches forecast command expectation."""
         downloader = GFSForecastDownloader(".")
 
         # forecast command expects f"{date.strftime('%Y%m%d')}-{hour:02d}.grib2"
-        # See cli/__init__.py line 970
+        # See cli/__init__.py line 1091
         date = dt.date(2025, 1, 4)
         hour = 6
 
@@ -46,7 +91,7 @@ class TestGFSForecastDownloader:
         downloader = GFSForecastDownloader(".")
 
         # forecast command expects [6, 12, 18]
-        # See cli/__init__.py line 969
+        # See cli/__init__.py line 80
         assert downloader.forecast_hours == [6, 12, 18]
 
     @pytest.mark.parametrize(
@@ -67,7 +112,7 @@ class TestGFSForecastDownloader:
         assert downloader.forecasts_dir.name == "forecasts"
 
     def test_nomads_url_different_hours(self):
-        """Test NOMADS URL for different forecast hours."""
+        """Test NOMADS URL for different forecast hours (legacy method)."""
         downloader = GFSForecastDownloader(".")
 
         url_00 = downloader._build_nomads_url("20250104", 0)
@@ -86,6 +131,34 @@ class TestGFSForecastDownloader:
 
         assert "file=gfs.t18z.pgrb2.0p25.f000" in url_18
         assert "dir=%2Fgfs.20250104%2F18" in url_18
+
+    def test_nomads_url_with_offset_different_run_hours(self):
+        """Test NOMADS URL with offset for different run hours."""
+        downloader = GFSForecastDownloader(".")
+
+        # 00Z run
+        url_00, run_00 = downloader._build_nomads_url_with_offset("2026010400", 6)
+        assert "file=gfs.t00z.pgrb2.0p25.f006" in url_00
+        assert "dir=%2Fgfs.20260104%2F00%2Fatmos" in url_00
+        assert run_00.hour == 0
+
+        # 06Z run
+        url_06, run_06 = downloader._build_nomads_url_with_offset("2026010406", 12)
+        assert "file=gfs.t06z.pgrb2.0p25.f012" in url_06
+        assert "dir=%2Fgfs.20260104%2F06%2Fatmos" in url_06
+        assert run_06.hour == 6
+
+        # 12Z run
+        url_12, run_12 = downloader._build_nomads_url_with_offset("2026010412", 18)
+        assert "file=gfs.t12z.pgrb2.0p25.f018" in url_12
+        assert "dir=%2Fgfs.20260104%2F12%2Fatmos" in url_12
+        assert run_12.hour == 12
+
+        # 18Z run
+        url_18, run_18 = downloader._build_nomads_url_with_offset("2026010418", 24)
+        assert "file=gfs.t18z.pgrb2.0p25.f024" in url_18
+        assert "dir=%2Fgfs.20260104%2F18%2Fatmos" in url_18
+        assert run_18.hour == 18
 
     def test_nomads_url_contains_all_required_vars(self):
         """Test that NOMADS URL contains all required weather variables."""
@@ -117,10 +190,59 @@ class TestGFSForecastDownloader:
         # Absolute vorticity
         assert "var_ABSV=on" in url
 
+    def test_nomads_url_with_offset_contains_all_required_vars(self):
+        """Test that URL with offset contains all required weather variables."""
+        downloader = GFSForecastDownloader(".")
+        url, _ = downloader._build_nomads_url_with_offset("2026010418", 12)
+
+        # Temperature
+        assert "var_TMP=on" in url
+
+        # Wind components
+        assert "var_UGRD=on" in url
+        assert "var_VGRD=on" in url
+
+        # Humidity
+        assert "var_RH=on" in url
+
+        # Precipitable water
+        assert "var_PWAT=on" in url
+
+        # Cloud water
+        assert "var_CWAT=on" in url
+
+        # Geopotential height
+        assert "var_HGT=on" in url
+
+        # Vertical velocity
+        assert "var_VVEL=on" in url
+
+        # Absolute vorticity
+        assert "var_ABSV=on" in url
+
     def test_nomads_url_contains_all_required_levels(self):
         """Test that NOMADS URL contains all required pressure levels."""
         downloader = GFSForecastDownloader(".")
         url = downloader._build_nomads_url("20250104", 0)
+
+        # Pressure levels
+        assert "lev_200_mb=on" in url
+        assert "lev_300_mb=on" in url
+        assert "lev_400_mb=on" in url
+        assert "lev_500_mb=on" in url
+        assert "lev_600_mb=on" in url
+        assert "lev_700_mb=on" in url
+        assert "lev_800_mb=on" in url
+        assert "lev_900_mb=on" in url
+        assert "lev_1000_mb=on" in url
+
+        # Entire atmosphere
+        assert "lev_entire_atmosphere=on" in url
+
+    def test_nomads_url_with_offset_contains_all_required_levels(self):
+        """Test that URL with offset contains all required pressure levels."""
+        downloader = GFSForecastDownloader(".")
+        url, _ = downloader._build_nomads_url_with_offset("2026010418", 12)
 
         # Pressure levels
         assert "lev_200_mb=on" in url


### PR DESCRIPTION
## Summary

Fixes forecast download functionality that was broken in PR #26:

## Changes

- **`_get_available_forecast_runs()`** - Scrapes NOMADS to find available forecast runs
- **`_build_nomads_url_with_offset()`** - Builds URL with correct forecast offset (f006, f012...)
- **Fixed URL directory**: `/gfs.YYYYMMDD/HH/atmos` (was missing `/HH/atmos`)
- **Added `--force` flag** - Re-downloads existing files
- **Updated CLI** - New options: `--days`, `--date`, `--start/--end`
- **Fixed tqdm display** - Now shows MB instead of kB
- **Updated README.md** - Documentation for new download commands

## Root Cause

In PR #26, the forecast downloader used:
- `f000` (analysis) instead of forecast offsets (f006, f012, ...)
- Wrong directory path: `/gfs.YYYYMMDD/HH` instead of `/gfs.YYYYMMDD/HH/atmos`

This caused 404 errors when downloading future dates.

## CLI Usage

```bash
# Download next 10 days from latest forecast run
pyparaglide dl forecast --days 10

# Download for specific date
pyparaglide dl forecast --date 2026-01-05

# Download for date range
pyparaglide dl forecast --start 2026-01-05 --end 2026-01-15

# Force re-download (overwrite existing files)
pyparaglide dl forecast --days 10 --force
```

## Testing

All 134 tests pass.

Closes #27