### PR TITLE
feat: add thermodynamic parameters and A/B testing framework

### DIFF
--- a/src/pyparaglide/cli/__init__.py
+++ b/src/pyparaglide/cli/__init__.py
@@ -486,7 +486,10 @@ def download_forecast(
     settings = get_settings()
 
     if data_dir is None:
-        data_dir = settings.gfs_dir
+        # Use parent of gfs_dir (data/gfs) instead of gfs_dir (data/gfs/anl)
+        # Forecast files should go to data/gfs/forecasts/, not data/gfs/anl/forecasts/
+        gfs_path = Path(settings.gfs_dir)
+        data_dir = str(gfs_path.parent if gfs_path.parent.name == "gfs" else gfs_path)
 
     # Parse hours
     hour_list = [int(h.strip()) for h in hours.split(",")]
@@ -605,6 +608,8 @@ def train(
     super_resolution: int = typer.Option(1, "--super-res", "-s", help="Super-resolution factor"),
     load_weights: bool = typer.Option(False, "--load-weights", help="Load existing weights"),
     early_stopping_patience: int = typer.Option(0, "--early-stopping-patience", "-p", help="Early stopping patience (0 = disabled, requires --validation)"),
+    thermo: bool = typer.Option(False, "--thermo", help="Enable thermodynamic parameters (PBLH, TCDC, CAPE, LI, CIN)"),
+    suffix: str = typer.Option("", "--suffix", help="Model suffix for versioning (e.g., '_thermo', '_baseline')"),
 ) -> None:
     """
     Train PyParaglide CELLS model for grid-based flyability prediction.
@@ -653,6 +658,8 @@ def train(
         super_resolution=super_resolution,
         load_weights=load_weights,
         early_stopping_patience=early_stopping_patience,
+        thermo=thermo,
+        suffix=suffix,
     )
 
 
@@ -668,12 +675,20 @@ def _train_cells(
     super_resolution: int,
     load_weights: bool,
     early_stopping_patience: int,
+    thermo: bool = False,
+    suffix: str = "",
 ) -> None:
     """Train CELLS model (all cells at once)."""
+    # Determine suffix if not provided
+    # Baseline: no suffix (cells.weights.h5), Thermo: _thermo suffix
+    if not suffix:
+        suffix = "_thermo" if thermo else ""
+
     console.print(f"[dim]Data directory: {data_dir}[/dim]")
     console.print(f"[dim]Models directory: {models_dir}[/dim]")
     console.print(f"[dim]Epochs: {epochs}, Batch size: {batch_size}[/dim]")
-    console.print(f"[dim]Learning rate: {lr_init} → {lr_end}[/dim]\n")
+    console.print(f"[dim]Learning rate: {lr_init} → {lr_end}[/dim]")
+    console.print(f"[dim]Thermo: {thermo}, Suffix: {suffix}[/dim]\n")
 
     # Create trainer
     trainer = Trainer(
@@ -681,6 +696,7 @@ def _train_cells(
         model_type=ModelType.CELLS,
         problem_formulation=ProblemFormulation.CLASSIFICATION,
         models_dir=models_dir,
+        thermo_dim=4 if thermo else 0,  # NEW: 4 thermo params (PBLH not available in GFS)
     )
 
     # Prepare data (all cells)
@@ -707,7 +723,7 @@ def _train_cells(
 
     # Save
     console.print("\n[yellow]Saving model...[/yellow]")
-    trainer.save_weights()
+    trainer.save_weights(suffix=suffix)  # NEW: use suffix for versioning
 
     # Results
     final_loss = history["loss"][-1]
@@ -922,7 +938,10 @@ def forecast(
     if models_dir is None:
         models_dir = settings.models_dir
     if grib_dir is None:
-        grib_dir = str(Path(settings.gfs_dir) / "forecasts")
+        # Use parent of gfs_dir (data/gfs) instead of gfs_dir (data/gfs/anl)
+        # Forecast files should be in data/gfs/forecasts/, not data/gfs/anl/forecasts/
+        gfs_path = Path(settings.gfs_dir)
+        grib_dir = str(gfs_path.parent / "forecasts" if gfs_path.parent.name == "gfs" else gfs_path / "forecasts")
     if output_dir is None:
         output_dir = settings.output_dir
     if bbox is None:
@@ -973,6 +992,124 @@ def forecast(
 
     console.print(f"\n[green]Forecast complete![/green]")
     console.print(f"Output: [cyan]{output_path}[/cyan]")
+
+
+@app.command()
+def forecast_ab_test(
+    date: str = typer.Option(None, "--date", "-d", help="Target date (YYYY-MM-DD, default: today)"),
+    models_dir: str = typer.Option(None, "--models-dir", help="Directory with model weights"),
+    grib_dir: str = typer.Option(None, "--grib-dir", "-g", help="Directory containing GRIB files"),
+    output_dir: str = typer.Option(None, "--output-dir", "-o", help="Output directory for A/B test results"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box: lat_min,lat_max,lon_min,lon_max"),
+    baseline_variant: str = typer.Option("", "--baseline", help="Baseline model variant (default: empty for cells.weights.h5)"),
+    thermo_variant: str = typer.Option("thermo", "--thermo", help="Thermo model variant (default: thermo for cells_thermo.weights.h5)"),
+) -> None:
+    """
+    Generate A/B test forecast comparing baseline and thermo-enhanced models.
+
+    Example:
+        pyparaglide forecast-ab-test --date 2025-06-15
+    """
+    import datetime as dt
+    import json
+
+    import numpy as np  # NEW: needed for np.mean in comparison
+
+    settings = get_settings()
+
+    # Use defaults from settings if not specified
+    if models_dir is None:
+        models_dir = settings.models_dir
+    if grib_dir is None:
+        # Use parent of gfs_dir (data/gfs) instead of gfs_dir (data/gfs/anl)
+        # Forecast files should be in data/gfs/forecasts/, not data/gfs/anl/forecasts/
+        gfs_path = Path(settings.gfs_dir)
+        grib_dir = str(gfs_path.parent / "forecasts" if gfs_path.parent.name == "gfs" else gfs_path / "forecasts")
+    if output_dir is None:
+        output_dir = str(Path(settings.output_dir) / "ab_tests")
+    if bbox is None:
+        bbox = settings.bbox
+
+    # Parse date
+    if date is None:
+        target_date = dt.date.today()
+    else:
+        try:
+            target_date = dt.datetime.strptime(date, "%Y-%m-%d").date()
+        except ValueError:
+            console.print(f"[red]Invalid date format: {date}[/red]")
+            console.print("Use format: [cyan]YYYY-MM-DD[/cyan]")
+            raise typer.Exit(1)
+
+    console.print(f"[bold cyan]A/B Testing: baseline vs thermo[/bold cyan]")
+    console.print(f"[dim]Date: {target_date.isoformat()}[/dim]")
+    console.print(f"[dim]Models: {models_dir}[/dim]")
+    console.print(f"[dim]Baseline: {baseline_variant}, Thermo: {thermo_variant}[/dim]\n")
+
+    # Find GRIB files for the target date
+    grib_path = Path(grib_dir)
+    grib_files = []
+    for hour in [6, 12, 18]:
+        grib_file = grib_path / f"{target_date.strftime('%Y%m%d')}-{hour:02d}.grib2"
+        if grib_file.exists():
+            grib_files.append(grib_file)
+        else:
+            console.print(f"[yellow]Warning: GRIB file not found: {grib_file}[/yellow]")
+
+    if len(grib_files) < 3:
+        console.print(f"[red]Error: Found only {len(grib_files)}/3 GRIB files[/red]")
+        console.print("Expected files for 06h, 12h, 18h forecasts")
+        raise typer.Exit(1)
+
+    # Create output directory
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Generate baseline forecast
+    console.print("[yellow]Loading baseline model...[/yellow]")
+    forecaster_baseline = Forecaster(models_dir, ProblemFormulation.CLASSIFICATION, model_variant=baseline_variant)
+
+    console.print("[yellow]Running baseline prediction...[/yellow]")
+    results_baseline = forecaster_baseline.predict_day(grib_files, target_date, tuple(float(x) for x in bbox.split(",")))
+
+    # Generate thermo forecast
+    console.print("[yellow]Loading thermo model...[/yellow]")
+    forecaster_thermo = Forecaster(models_dir, ProblemFormulation.CLASSIFICATION, model_variant=thermo_variant)
+
+    console.print("[yellow]Running thermo prediction...[/yellow]")
+    results_thermo = forecaster_thermo.predict_day(grib_files, target_date, tuple(float(x) for x in bbox.split(",")))
+
+    # Compare results
+    # Extract flyability values from predictions list
+    baseline_flyability = [p["flyability"] for p in results_baseline.get("predictions", [])]
+    thermo_flyability = [p["flyability"] for p in results_thermo.get("predictions", [])]
+
+    baseline_mean = np.mean(baseline_flyability) if baseline_flyability else 0.0
+    thermo_mean = np.mean(thermo_flyability) if thermo_flyability else 0.0
+    difference = thermo_mean - baseline_mean
+
+    comparison = {
+        "date": target_date.isoformat(),
+        "baseline_variant": baseline_variant,
+        "thermo_variant": thermo_variant,
+        "baseline_mean_flyability": float(baseline_mean),
+        "thermo_mean_flyability": float(thermo_mean),
+        "difference_mean_flyability": float(difference),
+        "baseline_results": results_baseline,
+        "thermo_results": results_thermo,
+    }
+
+    # Save results
+    output_file = output_path / f"ab_test_{target_date.isoformat()}.json"
+    console.print("[yellow]Saving A/B test results...[/yellow]")
+    with open(output_file, "w") as f:
+        json.dump(comparison, f, indent=2)
+
+    console.print(f"\n[green]A/B test complete![/green]")
+    console.print(f"Baseline mean flyability: [cyan]{baseline_mean:.4f}[/cyan]")
+    console.print(f"Thermo mean flyability: [cyan]{thermo_mean:.4f}[/cyan]")
+    console.print(f"Difference: [cyan]{difference:+.4f}[/cyan]")
+    console.print(f"Output: [cyan]{output_file}[/cyan]")
 
 
 @app.command()

--- a/src/pyparaglide/data/dataset.py
+++ b/src/pyparaglide/data/dataset.py
@@ -75,6 +75,15 @@ class Dataset:
         ("Cloud water", [0]),
     ]
 
+    # Thermodynamic parameters (surface/entire atmosphere)
+    # Note: PBLH is NOT available in GFS analysis data, using 4 thermo params instead of 5
+    _DEFS_THERMO = [
+        ("Total Cloud Cover", [0]),                   # TCDC - entire atmosphere
+        ("Convective available potential energy", [0]), # CAPE - surface
+        ("Surface lifted index", [0]),                # LI - surface
+        ("Convective inhibition", [0]),               # CIN - surface
+    ]
+
     def __init__(self, data_dir: Path | str):
         """
         Initialize dataset.
@@ -104,6 +113,7 @@ class Dataset:
         self.params_other = [[], [], []]
         self.params_wind = [[], [], []]
         self.params_humidity = [[], [], []]
+        self.params_thermo = [[], [], []]  # NEW: thermodynamic parameters
 
         for h_idx, hour in enumerate(hours):
             # OTHER
@@ -132,6 +142,31 @@ class Dataset:
                         self.params_humidity[h_idx].append(found)
                     else:
                          print(f"Warning: Missing param {name} {level} at {hour}h")
+
+            # THERMO (NEW)
+            for name, levels in self._DEFS_THERMO:
+                for level in levels:
+                    found = self._find_param(hour, name, level)
+                    if found:
+                        self.params_thermo[h_idx].append(found)
+                    else:
+                        print(f"Warning: Missing thermo param {name} {level} at {hour}h")
+
+        # NEW: Validate thermo parameters availability
+        thermo_count = sum(len(params) for params in self.params_thermo)
+        if thermo_count == 0:
+            import sys
+            print("\n" + "=" * 70)
+            print("ERROR: Thermodynamic parameters not found in dataset!")
+            print("=" * 70)
+            print("\nThe current dataset was built before thermo parameters were added.")
+            print("To use --thermo flag, you must rebuild the dataset with the new parameters:\n")
+            print("  1. Rebuild dataset:")
+            print("     pyparaglide build-dataset --rebuild-cache")
+            print("\n  2. Or train without thermo (baseline model):")
+            print("     pyparaglide train --epochs 55")
+            print("\n" + "=" * 70)
+            sys.exit(1)
 
     def _find_param(self, hour: int, name: str, level: int) -> tuple | None:
         """Find a parameter tuple in meteo_params."""
@@ -190,8 +225,25 @@ class Dataset:
             Array of shape (len(cells)*nb_days, len(params))
         """
         lines = self.get_lines(cells)
-        param_indices = [self.meteo_params.index(p) for p in params]
+        param_indices = [i for i, p in enumerate(self.meteo_params) if p in params]
         return self.meteo_content[lines][:, param_indices]
+
+    def get_thermo_matrix(self, cells: list[int]) -> np.ndarray:
+        """
+        Get thermo data for specific cells.
+
+        Returns array of shape (len(cells)*nb_days, 15) for 5 params × 3 hours.
+
+        Args:
+            cells: List of cell indices
+
+        Returns:
+            Array of shape (len(cells)*nb_days, 5*3=15)
+        """
+        all_params = []
+        for h_idx in range(3):
+            all_params.extend(self.params_thermo[h_idx])
+        return self.get_meteo_matrix(cells, all_params)
 
     def get_dow(self) -> np.ndarray:
         """Get day-of-week one-hot encoding."""

--- a/src/pyparaglide/data/normalization.py
+++ b/src/pyparaglide/data/normalization.py
@@ -16,13 +16,34 @@ class Normalization:
     other_std: np.ndarray
     humidity_mean: np.ndarray
     humidity_std: np.ndarray
+    thermo_mean: np.ndarray | None = None  # NEW: thermodynamic parameters
+    thermo_std: np.ndarray | None = None   # NEW
 
-    def save(self, path: Path | str) -> None:
+    def save(self, path: Path | str, suffix: str = "") -> None:
         """Save normalization coefficients to file."""
         import pickle
 
-        with open(path, "wb") as f:
-            pickle.dump([self.other_mean, self.other_std, self.humidity_mean, self.humidity_std], f)
+        # Build data list based on what's available
+        if self.thermo_mean is not None:
+            data = [
+                self.other_mean, self.other_std,
+                self.humidity_mean, self.humidity_std,
+                self.thermo_mean, self.thermo_std,
+            ]
+        else:
+            data = [
+                self.other_mean, self.other_std,
+                self.humidity_mean, self.humidity_std,
+            ]
+
+        # Add suffix if provided
+        save_path = Path(path)
+        if suffix:
+            stem = save_path.stem.split("_normalization_cells")[0]
+            save_path = save_path.parent / f"normalization_cells_{suffix}{save_path.suffix}"
+
+        with open(save_path, "wb") as f:
+            pickle.dump(data, f)
 
     @staticmethod
     def load(path: Path | str) -> "Normalization":
@@ -31,7 +52,21 @@ class Normalization:
 
         with open(path, "rb") as f:
             data = pickle.load(f)
-        return Normalization(other_mean=data[0], other_std=data[1], humidity_mean=data[2], humidity_std=data[3])
+
+        # Handle both old (4 elements) and new (6 elements) formats
+        if len(data) == 6:
+            return Normalization(
+                other_mean=data[0], other_std=data[1],
+                humidity_mean=data[2], humidity_std=data[3],
+                thermo_mean=data[4], thermo_std=data[5],
+            )
+        else:
+            # Legacy format without thermo
+            return Normalization(
+                other_mean=data[0], other_std=data[1],
+                humidity_mean=data[2], humidity_std=data[3],
+                thermo_mean=None, thermo_std=None,
+            )
 
 
 def compute_normalization_coeffs(data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/pyparaglide/inference/forecast.py
+++ b/src/pyparaglide/inference/forecast.py
@@ -30,6 +30,7 @@ class Forecaster:
         self,
         models_dir: Path | str,
         problem_formulation: ProblemFormulation = ProblemFormulation.CLASSIFICATION,
+        model_variant: str = "",  # NEW: "" for default, or "baseline", "thermo", etc.
     ):
         """
         Initialize forecaster.
@@ -37,9 +38,11 @@ class Forecaster:
         Args:
             models_dir: Directory containing trained model weights
             problem_formulation: CLASSIFICATION or REGRESSION
+            model_variant: Model variant for A/B testing (e.g., "baseline", "thermo")
         """
         self.models_dir = Path(models_dir)
         self.problem_formulation = problem_formulation
+        self.model_variant = model_variant  # NEW
 
         # Model parameters
         self.wind_dim = 8
@@ -49,7 +52,7 @@ class Forecaster:
         # Model and normalization (loaded later)
         self.model: tf.keras.Model | None = None
         self.normalization: Normalization | None = None
-        
+
         # Mountainess data (loaded from models_dir)
         self.mountainess_data: np.ndarray | None = None
 
@@ -60,7 +63,9 @@ class Forecaster:
         Returns:
             Number of cells detected from weights
         """
-        weight_path = self.models_dir / "cells.weights.h5"
+        # Use variant-specific weight file
+        suffix = f"_{self.model_variant}" if self.model_variant else ""
+        weight_path = self.models_dir / f"cells{suffix}.weights.h5"
 
         import h5py
 
@@ -91,8 +96,10 @@ class Forecaster:
 
     def load_model(self) -> None:
         """Load trained CELLS model and normalization coefficients."""
-        # Load normalization
-        norm_path = self.models_dir / "normalization_cells.pkl"
+        # Use variant-specific file paths
+        suffix = f"_{self.model_variant}" if self.model_variant else ""
+        norm_path = self.models_dir / f"normalization_cells{suffix}.pkl"
+
         if norm_path.exists():
             self.normalization = Normalization.load(norm_path)
         else:
@@ -100,6 +107,9 @@ class Forecaster:
 
         # Detect nb_cells from weights file before creating model
         self.nb_cells = self._detect_nb_cells_from_weights()
+
+        # Detect thermo_dim from normalization (NEW)
+        thermo_dim = 4 if self.normalization.thermo_mean is not None else 0
 
         # Create and load CELLS model
         self.model = ModelCells.create_model(
@@ -109,17 +119,18 @@ class Forecaster:
             other_dim=self.normalization.other_mean.shape[0],
             humidity_dim=self.normalization.humidity_mean.shape[0],
             nb_altitudes=self.nb_altitudes,
+            thermo_dim=thermo_dim,  # NEW
             super_resolution=1,
         )
 
         # Load weights
-        weight_path = self.models_dir / "cells.weights.h5"
+        weight_path = self.models_dir / f"cells{suffix}.weights.h5"
         if weight_path.exists():
             self.model.load_weights(weight_path)
             print(f"[INFO] Loaded model from {weight_path}")
         else:
             raise FileNotFoundError(f"Model weights not found: {weight_path}")
-        
+
         # Load mountainess data
         self._load_mountainess_data()
 
@@ -176,31 +187,39 @@ class Forecaster:
 
         # Weather data from GRIB files
         # This is simplified - full implementation needs proper grid extraction
-        X_other, X_wind, X_humidity = self._extract_weather_data(readers, bbox)
+        X_other, X_wind, X_humidity, X_thermo = self._extract_weather_data(readers, bbox)
 
         # Mountainess data from elevation analysis
-        nb_cells = self.nb_cells
         X_mountainess = self._get_mountainess_inputs()
 
-        # Combine all inputs
-        return [X_date, X_dow, X_mountainess, X_other, X_humidity, X_wind]
+        # Combine all inputs (ALWAYS include thermo, even if empty for baseline models)
+        # Model always expects 7 inputs matching its signature
+        inputs = [X_date, X_dow, X_mountainess, X_other, X_humidity, X_wind, X_thermo]
+
+        return inputs
 
     def _extract_weather_data(
         self, readers: list[GribReader], bbox: tuple[float, float, float, float]
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
         Extract weather data from GRIB files.
 
         Returns:
-            (X_other, X_wind, X_humidity) tuple
+            (X_other, X_wind, X_humidity, X_thermo) tuple
+            X_thermo has shape (1, nb_cells, 3, thermo_dim) where thermo_dim=0 for baseline models
         """
         nb_hours = 3
         nb_cells = self.nb_cells
+
+        # Check if model expects thermo data and determine thermo_dim
+        thermo_dim = 4 if self.normalization.thermo_mean is not None else 0
 
         # Extract for each forecast hour
         X_other = np.zeros((1, nb_cells, nb_hours, 45), dtype=np.float32)  # 5 params × 9 levels
         X_humidity = np.zeros((1, nb_cells, nb_hours, 2), dtype=np.float32)  # PWAT, CWAT
         X_wind = np.zeros((1, nb_cells, 1, nb_hours, self.wind_dim), dtype=np.float32)  # nb_altitudes=1
+        # Always create thermo array (empty for baseline models with thermo_dim=0)
+        X_thermo = np.zeros((1, nb_cells, nb_hours, thermo_dim), dtype=np.float32)
 
         for h, reader in enumerate(readers):
             # This is simplified - proper implementation needs:
@@ -222,6 +241,19 @@ class Forecaster:
                     data = reader.get_bbox_data(name, bbox, None)
                     if data is not None:
                         X_humidity[0, cell_idx, h, param_idx] = np.mean(data)
+
+                # Extract thermo parameters (NEW) - 4 params (PBLH not available)
+                if thermo_dim > 0:
+                    thermo_params = [
+                        ("Total Cloud Cover", "atmosphere"),
+                        ("Convective available potential energy", "surface"),
+                        ("Surface lifted index", "surface"),
+                        ("Convective inhibition", "surface"),
+                    ]
+                    for param_idx, (name, level_type) in enumerate(thermo_params):
+                        data = reader.get_bbox_data(name, bbox, level_type)
+                        if data is not None:
+                            X_thermo[0, cell_idx, h, param_idx] = np.mean(data)
 
                 # Extract wind and convert to direction bins (averaged over 5 altitudes)
                 wind_dirs_avg = np.zeros(self.wind_dim, dtype=np.float32)
@@ -257,7 +289,15 @@ class Forecaster:
                         hum_flat[:, i] = (hum_flat[:, i] - self.normalization.humidity_mean[i]) / self.normalization.humidity_std[i]
                 X_humidity[0, :, h, :] = hum_flat.reshape(nb_cells, -1)
 
-        return X_other, X_wind, X_humidity
+                # Normalize thermo (NEW) - only if thermo_dim > 0 and normalization exists
+                if X_thermo.shape[-1] > 0 and self.normalization.thermo_mean is not None:
+                    thermo_flat = X_thermo[0, :, h, :].reshape(-1, X_thermo.shape[-1])
+                    for i in range(thermo_flat.shape[1]):
+                        if i < len(self.normalization.thermo_mean):
+                            thermo_flat[:, i] = (thermo_flat[:, i] - self.normalization.thermo_mean[i]) / self.normalization.thermo_std[i]
+                    X_thermo[0, :, h, :] = thermo_flat.reshape(nb_cells, -1)
+
+        return X_other, X_wind, X_humidity, X_thermo  # NEW: added X_thermo
 
     def _format_results(self, predictions: list[np.ndarray], target_date: dt.date, bbox: tuple[float, float, float, float]) -> dict[str, Any]:
         """Format CELLS prediction results into output dictionary."""
@@ -286,32 +326,36 @@ class Forecaster:
     def _load_mountainess_data(self) -> None:
         """
         Load mountainess data from mountainess_by_cell_alt.pkl file.
-        
+
         This file contains terrain mountainess values for each grid cell,
         computed from elevation data during model training.
         """
-        mountainess_path = self.models_dir / "mountainess_by_cell_alt.pkl"
-        
-        if mountainess_path.exists():
-            try:
-                with open(mountainess_path, "rb") as f:
-                    self.mountainess_data = pickle.load(f)
-                print(f"[INFO] Loaded mountainess data from {mountainess_path}")
-                
-                # Validate shape
-                if self.mountainess_data is not None and self.mountainess_data.shape[0] != self.nb_cells:
-                    print(f"[WARNING] Mountainess data has {self.mountainess_data.shape[0]} cells, "
-                          f"but model expects {self.nb_cells}. Using first {self.nb_cells} cells.")
-                    self.mountainess_data = self.mountainess_data[:self.nb_cells]
-                    
-            except Exception as e:
-                print(f"[WARNING] Failed to load mountainess data from {mountainess_path}: {e}")
-                print("[INFO] Using default mountainess values (zeros)")
-                self.mountainess_data = None
-        else:
-            print(f"[WARNING] Mountainess file not found: {mountainess_path}")
-            print("[INFO] Using default mountainess values (zeros)")
-            self.mountainess_data = None
+        settings = get_settings()
+
+        # Try pkl_dir first (where build-dataset saves it), then models_dir for backwards compatibility
+        for base_dir, desc in [(Path(settings.pkl_dir), "PKL directory"), (self.models_dir, "models directory")]:
+            mountainess_path = base_dir / "mountainess_by_cell_alt.pkl"
+
+            if mountainess_path.exists():
+                try:
+                    with open(mountainess_path, "rb") as f:
+                        self.mountainess_data = pickle.load(f)
+                    print(f"[INFO] Loaded mountainess data from {mountainess_path}")
+
+                    # Validate shape
+                    if self.mountainess_data is not None and self.mountainess_data.shape[0] != self.nb_cells:
+                        print(f"[WARNING] Mountainess data has {self.mountainess_data.shape[0]} cells, "
+                              f"but model expects {self.nb_cells}. Using first {self.nb_cells} cells.")
+                        self.mountainess_data = self.mountainess_data[:self.nb_cells]
+
+                    return  # Success, exit early
+
+                except Exception as e:
+                    print(f"[WARNING] Failed to load mountainess data from {mountainess_path}: {e}")
+
+        # If we get here, no file was found or loaded successfully
+        print("[INFO] Using default mountainess values (zeros)")
+        self.mountainess_data = None
     
     def _get_mountainess_inputs(self) -> np.ndarray:
         """

--- a/src/pyparaglide/models/layers.py
+++ b/src/pyparaglide/models/layers.py
@@ -19,13 +19,14 @@ class FlyabilityBlock(tf.keras.Model):
     """
     Main flyability prediction block.
 
-    Combines wind, other weather, and rain data to predict flyability.
+    Combines wind, other weather, rain, and thermo data to predict flyability.
     """
 
-    def __init__(self, other_dim: int, humidity_dim: int, name: str = "flyability_block"):
+    def __init__(self, other_dim: int, humidity_dim: int, thermo_dim: int = 0, name: str = "flyability_block"):
         super().__init__(name=name)
         self.other_dim = other_dim
         self.humidity_dim = humidity_dim
+        self.thermo_dim = thermo_dim  # NEW
         self.batch_normalization = True
         self.dropout_rate = 0.0
 
@@ -42,8 +43,8 @@ class FlyabilityBlock(tf.keras.Model):
         self.dense3 = tf.keras.layers.Dense(1, activation="sigmoid", name="Flyability_2")
 
     def call(self, inputs: list[tf.Tensor], training: bool = False) -> tf.Tensor:
-        wind, other, rain = inputs
-        x = self.concat([wind, other, rain])
+        wind, other, rain, thermo = inputs  # NEW: added thermo
+        x = self.concat([wind, other, rain, thermo])  # Now includes thermo
         x = self.dropout1(x, training=training)
         x = self.dense1(x)
         if self.batch_normalization:

--- a/src/pyparaglide/models/model_cells.py
+++ b/src/pyparaglide/models/model_cells.py
@@ -47,6 +47,7 @@ class ModelCells:
         other_dim: int,
         humidity_dim: int,
         nb_altitudes: int,
+        thermo_dim: int = 0,  # NEW: thermodynamic parameters
         super_resolution: int = 1,
         initialization: dict[str, Any] | None = None,
     ) -> tf.keras.Model:
@@ -101,6 +102,10 @@ class ModelCells:
             shape=(nb_cells, 1, 3, wind_dim), name="in_wind"  # nb_altitudes -> 1
         )
 
+        # NEW: Add thermo input (always created, even for baseline with thermo_dim=0)
+        input_thermo = tf.keras.layers.Input(
+            shape=(nb_cells, 3, thermo_dim), name="in_thermo"
+        )
         all_inputs = [
             input_date,
             input_dow,
@@ -108,6 +113,7 @@ class ModelCells:
             input_other,
             input_humidity,
             input_wind,
+            input_thermo,
         ]
 
         # ==============================================================================
@@ -115,7 +121,7 @@ class ModelCells:
         # ==============================================================================
 
         wind_block = WindBlockCells(name="wind_block_cells")
-        flyability_block = FlyabilityBlock(other_dim, humidity_dim, name="flyability_block")
+        flyability_block = FlyabilityBlock(other_dim, humidity_dim, thermo_dim, name="flyability_block")  # NEW: thermo_dim
         crossability_block = CrossabilityBlock(
             other_dim, humidity_dim, nb_altitudes, nb_cells, name="crossability_block"
         )
@@ -141,7 +147,8 @@ class ModelCells:
             nb_altitudes,
             other_dim,
             humidity_dim,
-            [wind_prediction, input_other, input_humidity],
+            [wind_prediction, input_other, input_humidity, input_thermo],  # NEW: added input_thermo
+            thermo_dim,  # NEW
         )
         crossability_prediction = crossability_block(
             [flyability_prediction, wind_prediction, input_other, input_humidity]
@@ -171,6 +178,7 @@ class ModelCells:
         input_dim_other: int,
         input_dim_rain: int,
         inputs: list[tf.Tensor],
+        input_dim_thermo: int = 0,  # NEW: thermo dimension
     ) -> tf.Tensor:
         """
         Encapsulate flyability prediction (simplified for nb_altitudes=1).
@@ -183,28 +191,32 @@ class ModelCells:
             nb_altitudes: Always 1 (altitude binning removed)
             input_dim_other: Other weather data dimensions
             input_dim_rain: Rain/humidity data dimensions
-            inputs: [wind, other, rain] tensors
+            input_dim_thermo: Thermo data dimensions
+            inputs: [wind, other, rain, thermo] tensors
 
         Returns:
             Flyability prediction reshaped to (batch, nb_cells, 1)
         """
-        wind, other, rain = inputs
+        wind, other, rain, thermo = inputs  # NEW: added thermo
 
         # Simplified reshaping for nb_altitudes=1 (no tiling needed)
         # Reshape to (batch * nb_cells, feature_dim) for flyability block processing
         reshape_in = tf.keras.layers.Lambda(
-            lambda x: [
+            lambda x, d_other=input_dim_other, d_rain=input_dim_rain, d_thermo=input_dim_thermo: [
                 # wind: (batch, nb_cells, 1, 3) -> (batch * nb_cells, 3)
                 tf.reshape(x[0], (-1, 3)),
                 # other: (batch, nb_cells, 3, input_dim_other) -> (batch * nb_cells, 3*input_dim_other)
-                tf.reshape(x[1], (-1, 3 * input_dim_other)),
+                tf.reshape(x[1], (-1, 3 * d_other)),
                 # rain: (batch, nb_cells, 3, input_dim_rain) -> (batch * nb_cells, 3*input_dim_rain)
-                tf.reshape(x[2], (-1, 3 * input_dim_rain)),
+                tf.reshape(x[2], (-1, 3 * d_rain)),
+                # thermo: (batch, nb_cells, 3, input_dim_thermo) -> (batch * nb_cells, 3*input_dim_thermo)
+                # IMPORTANT: Use explicit batch dimension from wind to avoid issues when d_thermo=0
+                tf.reshape(x[3], (tf.shape(x[0])[0] * tf.shape(x[0])[1], 3 * d_thermo)),
             ]
         )
 
         reshape_out = tf.keras.layers.Lambda(lambda x: tf.reshape(x, (-1, nb_cells, 1)))
 
-        pre = reshape_in([wind, other, rain])
+        pre = reshape_in([wind, other, rain, thermo])
         flyability_prediction = flyability_model(pre)
         return reshape_out(flyability_prediction)

--- a/src/pyparaglide/preprocessing/cache/grib_cache.py
+++ b/src/pyparaglide/preprocessing/cache/grib_cache.py
@@ -145,10 +145,10 @@ class GribCache:
 
         Args:
             grib_path: Path to source GRIB file (can be str or Path)
-            flatten: If True, return flat array (nb_cells * 65,), else (nb_cells, 65)
+            flatten: If True, return flat array (nb_cells * 69,), else (nb_cells, 69)
 
         Returns:
-            Cached values array - flat if flatten=True, else (nb_cells, 65)
+            Cached values array - flat if flatten=True, else (nb_cells, 69)
 
         Raises:
             FileNotFoundError: If cache file doesn't exist
@@ -181,9 +181,9 @@ class GribCache:
 
         Args:
             grib_path: Path to source GRIB file (can be str or Path)
-            values: Extracted parameter values array of shape (nb_cells, 65)
+            values: Extracted parameter values array of shape (nb_cells, 69)
             config: Configuration dict with 'bbox', 'cells_latlon', 'nb_cells'
-            params: List of 65 (name, level) tuples used for extraction (optional)
+            params: List of 69 (name, level) tuples used for extraction (optional)
         """
         grib_path = Path(grib_path)
         cache_path = self._get_full_cache_path(grib_path)

--- a/src/pyparaglide/preprocessing/phases/meteo_phase.py
+++ b/src/pyparaglide/preprocessing/phases/meteo_phase.py
@@ -303,7 +303,7 @@ class BuildMeteoPhase:
         return meteo_days
 
     def _build_meteo_params(self) -> List:
-        """Build list of weather parameters (195 total: 65 params x 3 hours)."""
+        """Build list of weather parameters (207 total: 65 params x 3 hours + 4 thermo x 3 hours)."""
         meteo_params = []
 
         for hour in [6, 12, 18]:
@@ -324,6 +324,12 @@ class BuildMeteoPhase:
                 for level in pressure_levels:
                     meteo_params.append((hour, param_name, [[('isobaricInhPa', level)]]))
 
+            # Thermodynamic parameters (NEW) - 4 params (PBLH not available in GFS)
+            meteo_params.append((hour, 'Total Cloud Cover', [[('atmosphere', 0)], [('atmosphereSingleLayer', 0)], [('unknown', 0)]]))
+            meteo_params.append((hour, 'Convective available potential energy', [[('surface', 0)]]))
+            meteo_params.append((hour, 'Surface lifted index', [[('surface', 0)]]))
+            meteo_params.append((hour, 'Convective inhibition', [[('surface', 0)]]))
+
         print(f"  Total parameters: {len(meteo_params)}")
         return meteo_params
 
@@ -333,7 +339,9 @@ class BuildMeteoPhase:
 
         if not self.meteo_days or GribReader is None:
             print("  WARNING: No meteo days or GRIB reader. Creating zeros matrix.")
-            matrix = np.zeros((0, 195), dtype=np.float32)
+            # Calculate expected parameters: 65 (base) + 5 (thermo) = 70 per hour, 3 hours = 210
+            num_params = len(self._build_meteo_params())
+            matrix = np.zeros((0, num_params), dtype=np.float32)
             self._save_pkl("meteo_content_by_cell_day", matrix)
             return
 
@@ -392,7 +400,7 @@ class BuildMeteoPhase:
         if not self.use_cache:
             missing_days = self.meteo_days[:]
 
-        # Build GRIB params (65 without hour dimension)
+        # Build GRIB params (70 without hour dimension: 65 base + 5 thermo)
         grib_params = []
         for param in ['Precipitable water', 'Cloud water']:
             grib_params.append((param, [('entireAtmosphere', 0), ('atmosphereSingleLayer', 0), ('unknown', 0)]))
@@ -403,8 +411,18 @@ class BuildMeteoPhase:
             for level in pressure_levels:
                 grib_params.append((param, [('isobaricInhPa', level)]))
 
-        if len(grib_params) != 65:
-            print(f"  ERROR: Expected 65 parameters, got {len(grib_params)}")
+        # Thermodynamic parameters (NEW) - using actual GRIB parameter names
+        # Note: PBLH is NOT available in GFS analysis data, using 4 thermo params instead of 5
+        # Total Cloud Cover exists with typeOfLevel='atmosphere'
+        grib_params.append(('Total Cloud Cover', [('atmosphere', 0), ('atmosphereSingleLayer', 0), ('unknown', 0)]))
+        # CAPE and CIN exist at surface
+        grib_params.append(('Convective available potential energy', [('surface', 0)]))
+        # Lifted Index exists as "Surface lifted index" (not "Best (4-layer)")
+        grib_params.append(('Surface lifted index', [('surface', 0)]))
+        grib_params.append(('Convective inhibition', [('surface', 0)]))
+
+        if len(grib_params) != 69:
+            print(f"  ERROR: Expected 69 parameters (65 base + 4 thermo), got {len(grib_params)}")
             return
 
         # Multiprocessing setup - process only missing_days
@@ -560,15 +578,15 @@ class BuildMeteoPhase:
         """
         Load meteo data from cache for specified days.
 
-        Produces matrix of shape (nb_days * nb_cells, 195) where each row is
-        [hour6_params(65), hour12_params(65), hour18_params(65)] for a single day-cell.
+        Produces matrix of shape (nb_days * nb_cells, 207) where each row is
+        [hour6_params(69), hour12_params(69), hour18_params(69)] for a single day-cell.
 
         Args:
             cache: GribCache instance
             days_to_load: List of dates to load (default: all self.meteo_days)
 
         Returns:
-            numpy array of shape (nb_days * nb_cells, 195)
+            numpy array of shape (nb_days * nb_cells, 207)
         """
         import numpy as np
 
@@ -583,12 +601,12 @@ class BuildMeteoPhase:
                 row_data = []
                 for hour in [6, 12, 18]:
                     grb_path = self.gfs_dir / day_date.strftime('%Y-%m') / f"gfsanl_3_{day_date.strftime('%Y%m%d')}_{hour:02d}00_000.grb2"
-                    # Load from cache (already validated) - returns (nb_cells, 65)
+                    # Load from cache (already validated) - returns (nb_cells, 69)
                     values = cache.load(grb_path, flatten=False)
-                    row_data.extend(values[cell_idx])  # Add this cell's 65 params for this hour
-                all_data.append(row_data)  # Append complete row of 195 values
+                    row_data.extend(values[cell_idx])  # Add this cell's 69 params for this hour
+                all_data.append(row_data)  # Append complete row of 207 values
 
-        # Convert to array - shape should be (nb_days * nb_cells, 195)
+        # Convert to array - shape should be (nb_days * nb_cells, 207)
         meteo_content = np.array(all_data, dtype=np.float32)
         return meteo_content
 

--- a/src/pyparaglide/preprocessing/phases/terrain_phase.py
+++ b/src/pyparaglide/preprocessing/phases/terrain_phase.py
@@ -100,6 +100,10 @@ class BuildTerrainPhase:
                 mountainess = self._get_mountainess(lat, lon)
                 mountainess_by_cell_alt.append([mountainess] * 5)
 
+        # Convert to numpy array for consistent shape handling
+        import numpy as np
+        mountainess_by_cell_alt = np.array(mountainess_by_cell_alt, dtype=np.float32)
+
         self._save_pkl("mountainess_by_cell_alt", mountainess_by_cell_alt)
 
         # Save metadata

--- a/src/pyparaglide/preprocessing/workers/grib_workers.py
+++ b/src/pyparaglide/preprocessing/workers/grib_workers.py
@@ -87,7 +87,7 @@ def file_processor(job_queue, hourly_queue, grib_params, cells_latlon, cache_dir
     Args:
         job_queue: Queue with (day_date, hour, temp_path) tuples
         hourly_queue: Queue for (day_date, hour, values) results
-        grib_params: List of 65 GRIB parameters to extract
+        grib_params: List of 69 GRIB parameters to extract (65 base + 4 thermo)
         cells_latlon: List of (lat, lon) cell coordinates
         cache_dir: Path to GRIB cache directory (None = disable cache)
     """
@@ -194,7 +194,7 @@ def file_processor(job_queue, hourly_queue, grib_params, cells_latlon, cache_dir
                 # Save to cache if enabled and grib_path is provided
                 if cache and grib_path and values is not None:
                     try:
-                        # Reshape flat values to (nb_cells, 65) for cache
+                        # Reshape flat values to (nb_cells, 69) for cache
                         cached_values = np.array(values, dtype=np.float32).reshape(len(cells_latlon), len(grib_params))
                         cache.save(
                             grib_path,
@@ -228,7 +228,7 @@ def assemble_day_results(hourly_queue, day_results_queue, num_params, num_cells)
     Args:
         hourly_queue: Queue with (day_date, hour, values) tuples
         day_results_queue: Queue where completed day_data is placed
-        num_params: Number of parameters (65)
+        num_params: Number of parameters per hour (69: 65 base + 4 thermo)
         num_cells: Number of cells
     """
     hours_collected = {}  # (day_date, hour) -> values list
@@ -265,7 +265,7 @@ def assemble_day_results(hourly_queue, day_results_queue, num_params, num_cells)
            (day_date, 18) in hours_collected:
 
             # Assemble day data: [cell1_values, cell2_values, ...]
-            # where cell_values = [hour6_param1..65, hour12_param1..65, hour18_param1..65]
+            # where cell_values = [hour6_param1..69, hour12_param1..69, hour18_param1..69]
             day_data = []
             for cell_idx in range(num_cells):
                 cell_values = []

--- a/src/pyparaglide/training/trainer.py
+++ b/src/pyparaglide/training/trainer.py
@@ -30,6 +30,7 @@ class Trainer:
         model_type: ModelType = ModelType.CELLS,
         problem_formulation: ProblemFormulation = ProblemFormulation.CLASSIFICATION,
         models_dir: Path | str = "data/models",
+        thermo_dim: int = 0,  # NEW: number of thermo parameters (0 or 4)
     ):
         """
         Initialize trainer.
@@ -39,11 +40,13 @@ class Trainer:
             model_type: Must be ModelType.CELLS
             problem_formulation: CLASSIFICATION or REGRESSION
             models_dir: Directory to save/load model weights
+            thermo_dim: Number of thermo parameters (0 for baseline, 4 for thermo-enhanced)
         """
         self.data_dir = Path(data_dir)
         self.model_type = model_type
         self.problem_formulation = problem_formulation
         self.models_dir = Path(models_dir)
+        self.thermo_dim = thermo_dim  # NEW
 
         # Model parameters
         self.wind_dim = 8
@@ -72,30 +75,62 @@ class Trainer:
         if cells is None:
             cells = list(range(self.nb_cells))
 
+        # NEW: Validate dataset integrity BEFORE loading any data
+        expected_cols = len(self.dataset.meteo_params)
+        actual_cols = self.dataset.meteo_content.shape[1]
+        if actual_cols != expected_cols:
+            import sys
+            if self.thermo_dim > 0 and actual_cols < expected_cols:
+                print("\n" + "=" * 70)
+                print("ERROR: Dataset out of sync - rebuild required!")
+                print("=" * 70)
+                print(f"\nDataset metadata expects {expected_cols} parameters")
+                print(f"Dataset data has {actual_cols} parameters")
+                print("\nThe dataset was partially updated but not fully rebuilt.")
+                print("You need to rebuild the dataset to include thermo parameters:\n")
+                print("  pyparaglide build-dataset --rebuild-cache")
+                print("\n" + "=" * 70)
+                sys.exit(1)
+
         # Load weather data for CELLS: meteo data is organized as (nb_cells * nb_days, dim)
         X_other = [self.dataset.get_meteo_matrix(cells, self.dataset.params_other[h]) for h in range(3)]
         X_wind = [convert_wind_matrix(self.dataset.get_meteo_matrix(cells, self.dataset.params_wind[h]), self.wind_dim) for h in range(3)]
         X_humidity = [self.dataset.get_meteo_matrix(cells, self.dataset.params_humidity[h]) for h in range(3)]
+
+        # Load thermo data if enabled (NEW)
+        X_thermo = None
+        if self.thermo_dim > 0:
+            # Now safe to access thermo parameters
+            X_thermo = [self.dataset.get_meteo_matrix(cells, self.dataset.params_thermo[h]) for h in range(3)]
 
         # Compute normalization (based on hour 1 = 12h)
         print("[INFO] Computing normalization from data")
         norm_mean_other, norm_std_other = compute_normalization_coeffs(X_other[1])
         norm_mean_hum, norm_std_hum = compute_normalization_coeffs(X_humidity[1])
 
+        # Compute thermo normalization if enabled (NEW)
+        norm_mean_thermo, norm_std_thermo = None, None
+        if X_thermo is not None:
+            norm_mean_thermo, norm_std_thermo = compute_normalization_coeffs(X_thermo[1])
+
         self.normalization = Normalization(
             other_mean=norm_mean_other,
             other_std=norm_std_other,
             humidity_mean=norm_mean_hum,
             humidity_std=norm_std_hum,
+            thermo_mean=norm_mean_thermo,  # NEW
+            thermo_std=norm_std_thermo,    # NEW
         )
 
         # Apply normalization
         for h in range(3):
             X_other[h] = apply_normalization(X_other[h], norm_mean_other, norm_std_other)
             X_humidity[h] = apply_normalization(X_humidity[h], norm_mean_hum, norm_std_hum)
+            if X_thermo is not None:  # NEW
+                X_thermo[h] = apply_normalization(X_thermo[h], norm_mean_thermo, norm_std_thermo)
 
         # Prepare inputs
-        X = self._prepare_inputs(cells, X_other, X_wind, X_humidity, super_resolution)
+        X = self._prepare_inputs(cells, X_other, X_wind, X_humidity, X_thermo, super_resolution)  # NEW: added X_thermo
         Y = self._prepare_outputs(cells, super_resolution)
 
         return X, Y
@@ -106,6 +141,7 @@ class Trainer:
         X_other: list[np.ndarray],
         X_wind: list[np.ndarray],
         X_humidity: list[np.ndarray],
+        X_thermo: list[np.ndarray] | None,  # NEW
         super_resolution: int,
     ) -> list:
         """Prepare input tensors for CELLS model."""
@@ -129,6 +165,19 @@ class Trainer:
         X_humidity_stacked = np.zeros((self.nb_days, nb_cells_model, 3, dim_humidity), dtype=np.float32)
 
         X_wind_stacked = np.zeros((self.nb_days, nb_cells_model, 1, 3, self.wind_dim), dtype=np.float32)
+
+        # Initialize thermo stacked array (ALWAYS create, even for baseline with thermo_dim=0)
+        # This ensures the model always receives 7 inputs matching its expected input signature
+        dim_thermo = self.thermo_dim  # 0 for baseline, 4 for thermo
+        X_thermo_stacked = np.zeros((self.nb_days, nb_cells_model, 3, dim_thermo), dtype=np.float32)
+
+        # Fill with actual thermo data if available
+        if X_thermo is not None:
+            for h in range(3):
+                for i, cell in enumerate(cells):
+                    start_idx = i * self.nb_days
+                    end_idx = start_idx + self.nb_days
+                    X_thermo_stacked[:, i, h, :] = X_thermo[h][start_idx:end_idx, :]
 
         for h in range(3):
             for i, cell in enumerate(cells):
@@ -154,7 +203,11 @@ class Trainer:
                 # Assign to stacked array
                 X_wind_stacked[:, i, 0, h, :] = wind_reshaped[:, 0, :]
 
-        return [X_date, X_dow, X_mountainess, X_other_stacked, X_humidity_stacked, X_wind_stacked]
+        # Build input list (ALWAYS include thermo - even when dim_thermo=0)
+        # Model expects 7 inputs matching its signature
+        inputs = [X_date, X_dow, X_mountainess, X_other_stacked, X_humidity_stacked, X_wind_stacked, X_thermo_stacked]
+
+        return inputs
 
     def _prepare_outputs(self, cells: list[int], super_resolution: int) -> list:
         """Prepare output tensors for CELLS model."""
@@ -198,6 +251,7 @@ class Trainer:
             other_dim=45,  # Will be updated from data
             humidity_dim=2,
             nb_altitudes=self.nb_altitudes,
+            thermo_dim=self.thermo_dim,  # NEW
             super_resolution=super_resolution,
         )
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -80,17 +80,19 @@ class TestFlyabilityBlock:
         """Test building and calling FlyabilityBlock."""
         other_dim = 45
         humidity_dim = 2
+        thermo_dim = 0  # baseline model
 
-        layer = FlyabilityBlock(other_dim, humidity_dim)
+        layer = FlyabilityBlock(other_dim, humidity_dim, thermo_dim)
         batch_size = 4
 
-        # Create inputs
+        # Create inputs (including thermo with empty last dimension)
         wind = tf.constant(np.random.randn(batch_size, 3), dtype=tf.float32)
         other = tf.constant(np.random.randn(batch_size, 3 * other_dim), dtype=tf.float32)
         rain = tf.constant(np.random.randn(batch_size, 3 * humidity_dim), dtype=tf.float32)
+        thermo = tf.constant(np.random.randn(batch_size, 3 * thermo_dim), dtype=tf.float32)  # empty for baseline
 
-        # Call layer
-        output = layer([wind, other, rain])
+        # Call layer with 4 inputs (wind, other, rain, thermo)
+        output = layer([wind, other, rain, thermo])
 
         # Check output shape: (batch, 1)
         assert output.shape == (batch_size, 1)
@@ -99,15 +101,17 @@ class TestFlyabilityBlock:
         """Test that output is in [0, 1] range (sigmoid activation)."""
         other_dim = 10
         humidity_dim = 2
+        thermo_dim = 0  # baseline model
 
-        layer = FlyabilityBlock(other_dim, humidity_dim)
+        layer = FlyabilityBlock(other_dim, humidity_dim, thermo_dim)
         batch_size = 10
 
         wind = tf.constant(np.random.randn(batch_size, 3) * 10, dtype=tf.float32)
         other = tf.constant(np.random.randn(batch_size, 3 * other_dim) * 10, dtype=tf.float32)
         rain = tf.constant(np.random.randn(batch_size, 3 * humidity_dim) * 10, dtype=tf.float32)
+        thermo = tf.constant(np.random.randn(batch_size, 3 * thermo_dim), dtype=tf.float32)  # empty for baseline
 
-        output = layer([wind, other, rain])
+        output = layer([wind, other, rain, thermo])
 
         # All values should be in [0, 1]
         assert np.all(output.numpy() >= 0.0)

--- a/tests/test_model_cells.py
+++ b/tests/test_model_cells.py
@@ -39,8 +39,8 @@ class TestModelCells:
         assert model is not None
         assert isinstance(model, tf.keras.Model)
 
-        # Check number of inputs
-        assert len(model.inputs) == 6
+        # Check number of inputs (7 inputs including in_thermo)
+        assert len(model.inputs) == 7
 
         # Check input names
         input_names = [inp.name.split(":")[0] for inp in model.inputs]
@@ -50,6 +50,7 @@ class TestModelCells:
         assert "in_other" in input_names
         assert "in_rain" in input_names
         assert "in_wind" in input_names
+        assert "in_thermo" in input_names
 
         # Check number of outputs (2 outputs: flown, crossed)
         assert len(model.outputs) == 2
@@ -79,12 +80,13 @@ class TestModelCells:
             other_dim=45,
             humidity_dim=2,
             nb_altitudes=1,
+            thermo_dim=0,  # baseline model
             super_resolution=1,
         )
 
         batch_size = 4
 
-        # Create inputs
+        # Create inputs (including in_thermo with empty last dimension)
         inputs = {
             "in_date": tf.constant(np.random.rand(batch_size, 1), dtype=tf.float32),
             "in_dow": tf.constant(np.random.rand(batch_size, 7), dtype=tf.float32),
@@ -92,6 +94,7 @@ class TestModelCells:
             "in_other": tf.constant(np.random.randn(batch_size, 1, 3, 45), dtype=tf.float32),
             "in_rain": tf.constant(np.random.randn(batch_size, 1, 3, 2), dtype=tf.float32),
             "in_wind": tf.constant(np.random.randn(batch_size, 1, 1, 3, 8), dtype=tf.float32),
+            "in_thermo": tf.constant(np.random.randn(batch_size, 1, 3, 0), dtype=tf.float32),  # empty thermo
         }
 
         # Run forward pass
@@ -113,6 +116,7 @@ class TestModelCells:
             other_dim=45,
             humidity_dim=2,
             nb_altitudes=1,
+            thermo_dim=0,  # baseline model
             super_resolution=1,
         )
 
@@ -125,6 +129,7 @@ class TestModelCells:
             "in_other": tf.constant(np.random.randn(batch_size, 1, 3, 45), dtype=tf.float32),
             "in_rain": tf.constant(np.random.randn(batch_size, 1, 3, 2), dtype=tf.float32),
             "in_wind": tf.constant(np.random.randn(batch_size, 1, 1, 3, 8), dtype=tf.float32),
+            "in_thermo": tf.constant(np.random.randn(batch_size, 1, 3, 0), dtype=tf.float32),  # empty thermo
         }
 
         outputs = model(inputs)
@@ -145,6 +150,7 @@ class TestModelCells:
             other_dim=45,
             humidity_dim=2,
             nb_altitudes=1,
+            thermo_dim=0,  # baseline model
             super_resolution=super_resolution,
         )
 
@@ -157,6 +163,7 @@ class TestModelCells:
             "in_other": tf.constant(np.random.randn(batch_size, 1, 3, 45), dtype=tf.float32),
             "in_rain": tf.constant(np.random.randn(batch_size, 1, 3, 2), dtype=tf.float32),
             "in_wind": tf.constant(np.random.randn(batch_size, 1, 1, 3, 8), dtype=tf.float32),
+            "in_thermo": tf.constant(np.random.randn(batch_size, 1, 3, 0), dtype=tf.float32),  # empty thermo
         }
 
         outputs = model(inputs)
@@ -236,16 +243,18 @@ class TestModelCellsEncapsulateFlyability:
         nb_altitudes = 1  # Changed from 5
         other_dim = 45
         humidity_dim = 2
+        thermo_dim = 0  # baseline model
 
         # Create simple flyability block that matches FlyabilityBlock interface
-        # It expects a list of 3 inputs: wind, other, rain
+        # It expects a list of 4 inputs: wind, other, rain, thermo
         input_wind = tf.keras.layers.Input(shape=(3,), name="test_wind")
         input_other = tf.keras.layers.Input(shape=(3 * other_dim,), name="test_other")
         input_rain = tf.keras.layers.Input(shape=(3 * humidity_dim,), name="test_rain")
-        merged = tf.keras.layers.Concatenate()([input_wind, input_other, input_rain])
+        input_thermo = tf.keras.layers.Input(shape=(3 * thermo_dim,), name="test_thermo")  # empty for baseline
+        merged = tf.keras.layers.Concatenate()([input_wind, input_other, input_rain, input_thermo])
         dense1 = tf.keras.layers.Dense(16, activation="tanh")(merged)
         output = tf.keras.layers.Dense(1, activation="sigmoid")(dense1)
-        flyability_block = tf.keras.Model([input_wind, input_other, input_rain], output)
+        flyability_block = tf.keras.Model([input_wind, input_other, input_rain, input_thermo], output)
 
         batch_size = 4
 
@@ -253,15 +262,17 @@ class TestModelCellsEncapsulateFlyability:
         wind = tf.constant(np.random.randn(batch_size, nb_cells, nb_altitudes, 3), dtype=tf.float32)
         other = tf.constant(np.random.randn(batch_size, nb_cells, 3, other_dim), dtype=tf.float32)
         rain = tf.constant(np.random.randn(batch_size, nb_cells, 3, humidity_dim), dtype=tf.float32)
+        thermo = tf.constant(np.random.randn(batch_size, nb_cells, 3, thermo_dim), dtype=tf.float32)  # empty for baseline
 
-        # Call encapsulate_flyability
+        # Call encapsulate_flyability with 4 inputs (including thermo)
         output = ModelCells._encapsulate_flyability(
             flyability_block,
             nb_cells,
             nb_altitudes,
             other_dim,
             humidity_dim,
-            [wind, other, rain],
+            [wind, other, rain, thermo],  # inputs list comes before input_dim_thermo
+            thermo_dim,
         )
 
         # Check output shape: (batch, nb_cells, 1) after altitude binning removal


### PR DESCRIPTION
## Summary

Add thermodynamic parameters (TCDC, CAPE, LI, CIN) to improve model accuracy and introduce A/B testing framework for comparing model variants.

## Changes

### Core Model
- **FlyabilityBlock**: Add `thermo_dim` parameter for thermodynamic inputs
- **ModelCells**: Add thermo input layer (always present, dim=0 for baseline models)
- **Normalization**: Handle thermo parameters with backward compatibility

### Dataset & Training
- **Dataset**: Add 4 thermo params × 3 hours = 15 features
- **CLI**: Add `--thermo` flag for thermo-enhanced models
- **CLI**: Add `--suffix` flag for model versioning (e.g., `_thermo`, `_baseline`)
- **Trainer**: Save/load variant-specific weights and normalization

### CLI Commands
- **forecast-ab-test**: New command for comparing model variants (baseline vs thermo)
- **download-forecast**: Fix GRIB path to use `data/gfs/forecasts`
- **train**: Add `--thermo` and `--suffix` options

### Forecast
- **Forecaster**: Add `model_variant` parameter for variant-specific weights
- **_extract_weather_data**: Include thermo parameters from GRIB files
- **_load_mountainess**: Search `pkl_dir` first, then `models_dir` for backward compatibility

### Bug Fixes
- **terrain_phase.py**: Save mountainess as numpy array instead of list
- **forecast GRIB path**: Correctly use `data/gfs/forecasts` not `data/gfs/anl/forecasts`

### Tests
- Update `test_layers.py` and `test_model_cells.py` for thermo support

## Usage

```bash
# Train baseline model
pyparaglide train --epochs 55 --suffix ""

# Train thermo-enhanced model
pyparaglide train --epochs 55 --thermo --suffix "_thermo"

# Compare models
pyparaglide forecast-ab-test --date 2026-01-08
```

## Test plan

- [x] Train baseline model with `--suffix ""`
- [x] Train thermo model with `--thermo --suffix "_thermo"`
- [x] Run A/B test comparison with `forecast-ab-test`
- [x] Verify forecast loads correct mountainess data from `pkl_dir`